### PR TITLE
Enhance triage differential outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ symptoms = ["shortness_of_breath", "wheezing"]
 complaint = generator.generate_complaint(symptoms, "J45.9")
 print(complaint)
 
-predictions = discriminator.predict_diagnosis([complaint])
-print(predictions[0])
+predictions = discriminator.predict_diagnosis([complaint], top_k=3)
+for candidate in predictions[0]:
+    print(candidate["condition_code"], candidate["probability"])
 ```
 
 ## Repository Guide

--- a/phaita/data/__init__.py
+++ b/phaita/data/__init__.py
@@ -3,5 +3,6 @@ PHAITA Data Layer - Medical conditions and data processing utilities.
 """
 
 from .icd_conditions import RespiratoryConditions
+from .red_flags import RESPIRATORY_RED_FLAGS
 
-__all__ = ["RespiratoryConditions"]
+__all__ = ["RespiratoryConditions", "RESPIRATORY_RED_FLAGS"]

--- a/phaita/data/red_flags.py
+++ b/phaita/data/red_flags.py
@@ -1,0 +1,95 @@
+"""Curated red-flag guidance for respiratory conditions.
+
+Each entry maps an ICD-10 respiratory condition code to symptoms that
+should trigger escalation and a short piece of clinical advice for the
+triage assistant to surface to users.
+"""
+
+from typing import Dict, List, Union
+
+
+RESPIRATORY_RED_FLAGS: Dict[str, Dict[str, Union[List[str], str]]] = {
+    "J45.9": {
+        "symptoms": [
+            "inability to speak more than a few words",
+            "bluish lips or fingernails",
+            "peak flow < 50% of personal best"
+        ],
+        "escalation": "Use a rescue inhaler immediately and seek emergency care if symptoms do not improve within minutes."
+    },
+    "J18.9": {
+        "symptoms": [
+            "confusion or altered mental status",
+            "rapid breathing > 30 breaths per minute",
+            "oxygen saturation below 92%"
+        ],
+        "escalation": "Urgent evaluation in an emergency department is recommended, especially for older adults or those with chronic illness."
+    },
+    "J44.9": {
+        "symptoms": [
+            "severe breathlessness at rest",
+            "worsening swelling in legs or abdomen",
+            "drowsiness or new confusion"
+        ],
+        "escalation": "Initiate rescue medications and contact emergency services if breathing support is not available at home."
+    },
+    "J06.9": {
+        "symptoms": [
+            "stridor or noisy breathing at rest",
+            "inability to swallow fluids",
+            "signs of dehydration in infants or older adults"
+        ],
+        "escalation": "Seek urgent care if breathing becomes noisy, swallowing is impaired, or hydration cannot be maintained."
+    },
+    "J20.9": {
+        "symptoms": [
+            "high fever lasting more than 3 days",
+            "bloody sputum",
+            "shortness of breath at rest"
+        ],
+        "escalation": "Schedule prompt medical review; escalate to emergency services for breathing difficulty or blood in sputum."
+    },
+    "J81.0": {
+        "symptoms": [
+            "sudden severe breathlessness",
+            "frothy pink sputum",
+            "chest pain with sweating"
+        ],
+        "escalation": "Call emergency services immediately—acute pulmonary edema is a medical emergency."
+    },
+    "J93.0": {
+        "symptoms": [
+            "sudden stabbing chest pain",
+            "rapid collapse or fainting",
+            "asymmetrical chest movement"
+        ],
+        "escalation": "Seek emergency care without delay; a collapsed lung requires urgent intervention."
+    },
+    "J15.9": {
+        "symptoms": [
+            "persistent high fever",
+            "confusion or lethargy",
+            "oxygen saturation below 92%"
+        ],
+        "escalation": "Antibiotics may be required urgently—advise immediate clinical assessment."
+    },
+    "J12.9": {
+        "symptoms": [
+            "rapid breathing over 30 breaths per minute",
+            "difficulty speaking full sentences",
+            "lips or face turning blue"
+        ],
+        "escalation": "Advise emergency evaluation, particularly for high-risk groups such as infants and older adults."
+    },
+    "J21.9": {
+        "symptoms": [
+            "pauses in breathing (apnea)",
+            "poor feeding or dehydration",
+            "grunting or severe chest retractions"
+        ],
+        "escalation": "Infants with these signs need immediate emergency assessment and possible hospitalization."
+    }
+}
+
+
+__all__ = ["RESPIRATORY_RED_FLAGS"]

--- a/phaita/training/adversarial_trainer.py
+++ b/phaita/training/adversarial_trainer.py
@@ -396,9 +396,9 @@ class AdversarialTrainer:
         self.discriminator.eval()
         
         with torch.no_grad():
-            predictions = self.discriminator.predict_diagnosis(eval_complaints)
-            predicted_codes = [pred[0] for pred in predictions]
-            confidences = [pred[1] for pred in predictions]
+            predictions = self.discriminator.predict_diagnosis(eval_complaints, top_k=1)
+            predicted_codes = [pred[0]["condition_code"] for pred in predictions]
+            confidences = [pred[0]["probability"] for pred in predictions]
         
         # Compute metrics
         metrics = compute_diagnosis_metrics(eval_labels, predicted_codes, confidences)

--- a/phaita/triage/__init__.py
+++ b/phaita/triage/__init__.py
@@ -1,0 +1,11 @@
+"""Utilities for surfacing triage-ready differential diagnoses."""
+
+from .diagnosis import (
+    enrich_differential_with_guidance,
+    format_differential_report,
+)
+
+__all__ = [
+    "enrich_differential_with_guidance",
+    "format_differential_report",
+]

--- a/phaita/triage/diagnosis.py
+++ b/phaita/triage/diagnosis.py
@@ -1,0 +1,68 @@
+"""Helpers for presenting diagnosis predictions with clinical guidance."""
+
+from typing import Any, Dict, Iterable, List
+
+from ..data.red_flags import RESPIRATORY_RED_FLAGS
+
+
+def enrich_differential_with_guidance(
+    ranked_predictions: Iterable[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Attach red-flag and escalation guidance to ranked predictions.
+
+    Args:
+        ranked_predictions: Iterable of dictionaries produced by
+            :meth:`phaita.models.discriminator.DiagnosisDiscriminator.predict_diagnosis`.
+
+    Returns:
+        A list of dictionaries with additional ``red_flags`` and
+        ``escalation_advice`` keys.
+    """
+
+    enriched: List[Dict[str, Any]] = []
+    for entry in ranked_predictions:
+        code = entry.get("condition_code")
+        red_flag_data = RESPIRATORY_RED_FLAGS.get(code, {})
+        enriched_entry = dict(entry)
+        enriched_entry["red_flags"] = red_flag_data.get("symptoms", [])
+        enriched_entry["escalation_advice"] = red_flag_data.get("escalation", "")
+        enriched.append(enriched_entry)
+
+    return enriched
+
+
+def format_differential_report(ranked_predictions: Iterable[Dict[str, Any]]) -> str:
+    """Create a human-readable string summarising a ranked differential list."""
+
+    enriched_predictions = enrich_differential_with_guidance(ranked_predictions)
+    lines: List[str] = []
+
+    for idx, prediction in enumerate(enriched_predictions, start=1):
+        probability = prediction.get("probability", 0.0)
+        ci_lower, ci_upper = prediction.get("confidence_interval", (0.0, 0.0))
+        lines.append(
+            f"{idx}. {prediction.get('condition_name')} "
+            f"({prediction.get('condition_code')}) - "
+            f"p={probability:.2f} (95% CI {ci_lower:.2f}-{ci_upper:.2f})"
+        )
+
+        evidence = prediction.get("evidence", {})
+        key_symptoms = evidence.get("key_symptoms")
+        severity_indicators = evidence.get("severity_indicators")
+        description = evidence.get("description")
+
+        if key_symptoms:
+            lines.append(f"   🔎 Key symptoms: {', '.join(key_symptoms)}")
+        if severity_indicators:
+            lines.append(f"   🚨 Severe indicators: {', '.join(severity_indicators)}")
+        if description:
+            lines.append(f"   ℹ️  Summary: {description}")
+
+        red_flags = prediction.get("red_flags")
+        escalation = prediction.get("escalation_advice")
+        if red_flags:
+            lines.append(f"   ⚠️  Red flags: {', '.join(red_flags)}")
+        if escalation:
+            lines.append(f"   🚑 Escalation advice: {escalation}")
+
+    return "\n".join(lines)

--- a/test_triage_differential.py
+++ b/test_triage_differential.py
@@ -1,0 +1,33 @@
+"""Tests for triage differential formatting and guidance."""
+
+from phaita.models.discriminator import DiagnosisDiscriminator
+from phaita.triage import enrich_differential_with_guidance, format_differential_report
+
+
+def test_predict_diagnosis_honours_top_k_and_guidance():
+    model = DiagnosisDiscriminator(use_pretrained=False)
+
+    complaint = "I have a cough, fever, and my chest hurts when I breathe."
+    top_k = 4
+
+    differential_lists = model.predict_diagnosis([complaint], top_k=top_k)
+    assert len(differential_lists) == 1
+
+    ranked = differential_lists[0]
+    assert len(ranked) == top_k
+
+    # Probabilities should be in non-increasing order
+    probs = [entry["probability"] for entry in ranked]
+    assert probs == sorted(probs, reverse=True)
+
+    # Confidence interval should be a pair of floats inside [0, 1]
+    lower, upper = ranked[0]["confidence_interval"]
+    assert 0.0 <= lower <= upper <= 1.0
+
+    # Enriched guidance should include red flags and escalation messaging
+    enriched = enrich_differential_with_guidance(ranked)
+    assert enriched[0]["red_flags"], "Primary entry missing red-flag symptoms"
+    assert enriched[0]["escalation_advice"], "Primary entry missing escalation advice"
+
+    report = format_differential_report(ranked)
+    assert "Red flags" in report


### PR DESCRIPTION
## Summary
- extend the diagnosis discriminator to return ranked differential predictions with confidence intervals and evidence
- add curated respiratory red-flag guidance and helper utilities for formatting enriched differential reports
- update demos/CLI to surface the full differential with guidance and add regression tests covering ranking and red-flag content

## Testing
- pytest test_triage_differential.py

------
https://chatgpt.com/codex/tasks/task_e_68de88a8be208323a7689c3ed4f50a21