### PR TITLE
Add structured patient presentations for complaint generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,18 @@ python cli.py diagnose --complaint "I can't catch my breath"
 ### Python API Example
 ```python
 from phaita import AdversarialTrainer
-from phaita.models import ComplaintGenerator, DiagnosisDiscriminator
+from phaita.models import ComplaintGenerator, DiagnosisDiscriminator, SymptomGenerator
 
+symptom_gen = SymptomGenerator()
 generator = ComplaintGenerator()
 discriminator = DiagnosisDiscriminator()
 trainer = AdversarialTrainer(generator=generator, discriminator=discriminator)
 
-symptoms = ["shortness_of_breath", "wheezing"]
-complaint = generator.generate_complaint(symptoms, "J45.9")
-print(complaint)
+presentation = symptom_gen.generate_symptoms("J45.9")
+presentation = generator.generate_complaint(presentation=presentation)
+print(presentation.complaint_text)
 
-predictions = discriminator.predict_diagnosis([complaint], top_k=3)
+predictions = discriminator.predict_diagnosis([presentation.complaint_text], top_k=3)
 for candidate in predictions[0]:
     print(candidate["condition_code"], candidate["probability"])
 ```

--- a/cli.py
+++ b/cli.py
@@ -147,12 +147,13 @@ def demo_command(args):
         # Sample random condition
         code, condition_data = RespiratoryConditions.get_random_condition()
         
-        # Generate symptoms
-        symptoms = symptom_gen.bayesian_network.sample_symptoms(code)
-        
-        # Generate patient complaint
-        complaint = complaint_gen.generate_complaint(symptoms, code)
-        
+        # Generate structured presentation
+        presentation = symptom_gen.generate_symptoms(code)
+        presentation = complaint_gen.generate_complaint(
+            condition_code=code, presentation=presentation
+        )
+        complaint = presentation.complaint_text
+
         # Get diagnosis predictions
         predictions = discriminator.predict_diagnosis([complaint], top_k=args.top_k)
         report = format_differential_report(predictions[0])
@@ -162,7 +163,7 @@ def demo_command(args):
 
         print(f"\n🩺 Example {i+1}:")
         print(f"   True Condition: {code} - {condition_data['name']}")
-        print(f"   Symptoms: {', '.join(symptoms[:3])}...")
+        print(f"   Symptoms: {', '.join(presentation.symptoms[:3])}...")
         print(f"   Patient Says: \"{complaint}\"")
         print(f"   AI Primary Diagnosis: {pred_code} (probability: {confidence:.3f})")
         print("\n   Differential guidance:")
@@ -201,14 +202,24 @@ def generate_command(args):
             code, _ = RespiratoryConditions.get_random_condition()
         
         # Generate symptoms and complaint
-        symptoms = symptom_gen.bayesian_network.sample_symptoms(code)
-        complaint = complaint_gen.generate_complaint(symptoms, code)
-        
+        presentation = symptom_gen.generate_symptoms(code)
+        presentation = complaint_gen.generate_complaint(
+            condition_code=code, presentation=presentation
+        )
+
         results.append({
             'condition_code': code,
             'condition_name': RespiratoryConditions.get_condition_by_code(code)['name'],
-            'symptoms': symptoms,
-            'complaint': complaint
+            'symptoms': presentation.symptoms,
+            'complaint': presentation.complaint_text,
+            'symptom_probabilities': presentation.symptom_probabilities,
+            'misdescription_weights': presentation.misdescription_weights,
+            'vocabulary_profile': {
+                'allowed_terms': presentation.vocabulary_profile.allowed_terms,
+                'term_overrides': presentation.vocabulary_profile.term_overrides,
+                'register': presentation.vocabulary_profile.register,
+                'max_terms_per_response': presentation.vocabulary_profile.max_terms_per_response,
+            }
         })
     
     # Output results
@@ -485,7 +496,11 @@ def challenge_command(args):
 
         for i, case in enumerate(challenge_cases):
             try:
-                complaint = complaint_generator.generate_complaint(case["symptoms"], case["condition"])
+                presentation = complaint_generator.generate_complaint(
+                    condition_code=case["condition"],
+                    symptoms=case["symptoms"],
+                )
+                complaint = presentation.complaint_text
             except Exception:
                 complaint = _generate_complaint_from_symptoms(case["symptoms"], case.get("metadata", {}))
 

--- a/demo_fixes.py
+++ b/demo_fixes.py
@@ -87,9 +87,9 @@ def demo_task3():
     
     print("\nAFTER (with grammar fixes):")
     for i in range(5):
-        symptoms = gen.generate_symptoms('J45.9')
-        complaint = comp_gen.generate_complaint(symptoms, 'J45.9')
-        print(f"  ✓ {complaint}")
+        presentation = gen.generate_symptoms('J45.9')
+        presentation = comp_gen.generate_complaint(presentation=presentation)
+        print(f"  ✓ {presentation.complaint_text}")
     
     # Show grammar forms
     print("\n✓ Grammar rules applied:")

--- a/phaita/__init__.py
+++ b/phaita/__init__.py
@@ -14,6 +14,11 @@ from .data.icd_conditions import RespiratoryConditions
 from .models.generator import SymptomGenerator, ComplaintGenerator
 from .models.discriminator import DiagnosisDiscriminator
 from .models.bayesian_network import BayesianSymptomNetwork
+from .generation.patient_agent import (
+    PatientPresentation,
+    PatientSimulator,
+    VocabularyProfile,
+)
 
 # Import training components
 try:
@@ -43,6 +48,9 @@ __all__ = [
     "ComplaintGenerator",
     "DiagnosisDiscriminator",
     "BayesianSymptomNetwork",
-    "AdversarialTrainer", 
+    "PatientPresentation",
+    "PatientSimulator",
+    "VocabularyProfile",
+    "AdversarialTrainer",
     "Config"
 ]

--- a/phaita/data/synthetic_generator.py
+++ b/phaita/data/synthetic_generator.py
@@ -54,15 +54,25 @@ class SyntheticDataGenerator:
         variations = []
         
         for i in range(num_variations):
-            symptoms = self.symptom_gen.generate_symptoms(condition_code)
-            complaint = self.complaint_gen.generate_complaint(symptoms, condition_code)
-            
+            presentation = self.symptom_gen.generate_symptoms(condition_code)
+            presentation = self.complaint_gen.generate_complaint(
+                presentation=presentation
+            )
+
             variation = {
                 "id": f"{condition_code}_{i}",
                 "condition_code": condition_code,
                 "condition_name": self.conditions[condition_code]["name"],
-                "symptoms": symptoms,
-                "complaint": complaint
+                "symptoms": presentation.symptoms,
+                "complaint": presentation.complaint_text,
+                "symptom_probabilities": presentation.symptom_probabilities,
+                "misdescription_weights": presentation.misdescription_weights,
+                "vocabulary_profile": {
+                    "allowed_terms": presentation.vocabulary_profile.allowed_terms,
+                    "term_overrides": presentation.vocabulary_profile.term_overrides,
+                    "register": presentation.vocabulary_profile.register,
+                    "max_terms_per_response": presentation.vocabulary_profile.max_terms_per_response,
+                },
             }
             variations.append(variation)
         

--- a/phaita/generation/__init__.py
+++ b/phaita/generation/__init__.py
@@ -1,0 +1,13 @@
+"""Utilities for generating patient-facing content."""
+
+from .patient_agent import (
+    PatientSimulator,
+    PatientPresentation,
+    VocabularyProfile,
+)
+
+__all__ = [
+    "PatientSimulator",
+    "PatientPresentation",
+    "VocabularyProfile",
+]

--- a/phaita/generation/patient_agent.py
+++ b/phaita/generation/patient_agent.py
@@ -1,0 +1,97 @@
+"""Patient simulation utilities wrapping the Bayesian symptom network."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from ..models.bayesian_network import BayesianSymptomNetwork
+
+
+@dataclass
+class VocabularyProfile:
+    """Simple representation of how a patient describes their symptoms."""
+
+    allowed_terms: Optional[List[str]] = None
+    term_overrides: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    register: str = "informal"
+    max_terms_per_response: int = 3
+
+    @classmethod
+    def default_for(cls, symptoms: Sequence[str]) -> "VocabularyProfile":
+        """Create a baseline vocabulary profile from canonical symptom names."""
+        allowed = [symptom.replace("_", " ") for symptom in symptoms]
+        overrides = {symptom: {} for symptom in symptoms}
+        return cls(allowed_terms=allowed, term_overrides=overrides)
+
+    def translate(self, symptom: str, *, form: str, default: str) -> str:
+        """Translate a canonical symptom into the vocabulary for a given form."""
+        override = self.term_overrides.get(symptom, {})
+        candidate = override.get(form) if isinstance(override, dict) else None
+        if not candidate:
+            candidate = default
+        candidate = candidate.replace("_", " ")
+        if self.allowed_terms and candidate not in self.allowed_terms:
+            # Restrict to allowed terms while keeping signal
+            fallback = next((term for term in self.allowed_terms if term in candidate), None)
+            if fallback:
+                candidate = fallback
+            else:
+                candidate = self.allowed_terms[0]
+        return candidate
+
+
+@dataclass
+class PatientPresentation:
+    """Structured view of a simulated patient's presentation."""
+
+    condition_code: str
+    symptoms: List[str]
+    symptom_probabilities: Dict[str, float]
+    misdescription_weights: Dict[str, float]
+    vocabulary_profile: VocabularyProfile
+    complaint_text: Optional[str] = None
+    follow_up_history: List[Dict[str, str]] = field(default_factory=list)
+
+    def record_response(self, prompt: str, response: str) -> None:
+        """Record an exchange to keep the simulation stateful."""
+        self.follow_up_history.append({"prompt": prompt, "response": response})
+
+
+class PatientSimulator:
+    """Thin wrapper around :class:`BayesianSymptomNetwork`."""
+
+    def __init__(self, network: Optional[BayesianSymptomNetwork] = None):
+        self.network = network or BayesianSymptomNetwork()
+
+    def sample_presentation(
+        self,
+        condition_code: str,
+        *,
+        num_symptoms: Optional[int] = None,
+        vocabulary_profile: Optional[VocabularyProfile] = None,
+    ) -> PatientPresentation:
+        """Sample a presentation and bundle metadata about symptom probabilities."""
+        symptoms = self.network.sample_symptoms(condition_code, num_symptoms)
+        probabilities = self.network.get_conditional_probabilities(condition_code)
+        weights = {
+            name: max(0.0, 1.0 - probabilities.get(name, 0.0))
+            for name in probabilities.keys()
+        }
+        vocab = vocabulary_profile or VocabularyProfile.default_for(symptoms)
+        return PatientPresentation(
+            condition_code=condition_code,
+            symptoms=symptoms,
+            symptom_probabilities=probabilities,
+            misdescription_weights=weights,
+            vocabulary_profile=vocab,
+        )
+
+    def get_conditional_probabilities(
+        self, condition_code: str, symptoms: Optional[Iterable[str]] = None
+    ) -> Dict[str, float]:
+        """Expose conditional probabilities for external consumers."""
+        probabilities = self.network.get_conditional_probabilities(condition_code)
+        if symptoms is None:
+            return probabilities
+        return {symptom: probabilities.get(symptom, 0.0) for symptom in symptoms}

--- a/phaita/training/adversarial_trainer.py
+++ b/phaita/training/adversarial_trainer.py
@@ -266,12 +266,11 @@ class AdversarialTrainer:
             condition_code = random.choice(self.condition_codes)
             condition_codes.append(condition_code)
             
-            # Generate symptoms
-            symptoms = self.symptom_generator.bayesian_network.sample_symptoms(condition_code)
-            
-            # Generate patient complaint
-            complaint = self.complaint_generator.generate_complaint(symptoms, condition_code)
-            complaints.append(complaint)
+            presentation = self.symptom_generator.generate_symptoms(condition_code)
+            presentation = self.complaint_generator.generate_complaint(
+                presentation=presentation
+            )
+            complaints.append(presentation.complaint_text)
         
         # Create labels
         labels = []

--- a/test_integration.py
+++ b/test_integration.py
@@ -134,8 +134,9 @@ def test_task3_grammar_fixes():
         all_complaints = []
         
         for i in range(200):
-            symptoms = gen.generate_symptoms('J45.9')
-            complaint = comp_gen.generate_complaint(symptoms, 'J45.9')
+            presentation = gen.generate_symptoms('J45.9')
+            presentation = comp_gen.generate_complaint(presentation=presentation)
+            complaint = presentation.complaint_text
             all_complaints.append(complaint)
             
             # Check for bad patterns

--- a/test_patient_simulation.py
+++ b/test_patient_simulation.py
@@ -1,0 +1,52 @@
+import random
+
+import pytest
+
+from phaita.generation.patient_agent import PatientSimulator, VocabularyProfile
+from phaita.models.generator import ComplaintGenerator, SymptomGenerator
+
+
+def test_patient_presentation_metadata_consistency():
+    simulator = PatientSimulator()
+    presentation = simulator.sample_presentation("J45.9")
+
+    assert presentation.condition_code == "J45.9"
+    assert presentation.symptoms, "Expected sampled symptoms"
+    assert presentation.symptom_probabilities
+    assert presentation.misdescription_weights
+
+    for symptom, probability in presentation.symptom_probabilities.items():
+        assert 0.0 <= probability <= 1.0
+        weight = presentation.misdescription_weights.get(symptom)
+        assert weight is not None
+        assert weight == pytest.approx(max(0.0, 1.0 - probability), rel=1e-5)
+
+
+def test_complaint_generator_follow_up_respects_vocabulary():
+    random.seed(0)
+    symptom_generator = SymptomGenerator()
+    complaint_generator = ComplaintGenerator(use_pretrained=False)
+
+    vocabulary = VocabularyProfile.default_for(["cough", "shortness_of_breath"])
+    presentation = symptom_generator.generate_symptoms(
+        "J45.9", vocabulary_profile=vocabulary
+    )
+    presentation = complaint_generator.generate_complaint(presentation=presentation)
+
+    assert presentation.complaint_text
+
+    response = complaint_generator.answer_question(
+        "How long have you felt this way?", strategy="detailed"
+    )
+
+    # Follow-up responses should be recorded
+    assert presentation.follow_up_history
+    assert presentation.follow_up_history[-1]["response"] == response
+
+    # Ensure vocabulary constraints are respected
+    allowed_terms = set(vocabulary.allowed_terms or [])
+    if allowed_terms:
+        assert any(term in response for term in allowed_terms)
+    for symptom in presentation.symptoms:
+        if "_" in symptom:
+            assert symptom not in response


### PR DESCRIPTION
## Summary
- add a generation.patient_agent module providing PatientPresentation dataclasses with symptom probabilities, misdescription weights, and vocabulary profiles
- refactor the symptom and complaint generators plus CLI/demos to produce and consume the richer presentation metadata, including stateful follow-up responses
- extend synthetic data exports and tests to validate metadata fields and conversational consistency

## Testing
- pytest test_patient_simulation.py test_cli_regression.py

------
https://chatgpt.com/codex/tasks/task_e_68de90ec5a4c832394e37680bcaf2e73