### PR TITLE
Enhance triage question selection with information gain

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -130,6 +130,7 @@ def _run_triage_dialogue(
         return ranked_predictions
 
     ranked = predict_and_print("\n🔍 Initial differential:")
+    engine.update_differential(ranked)
 
     while not engine.should_present_diagnosis():
         prompt = engine.next_prompt()
@@ -150,6 +151,7 @@ def _run_triage_dialogue(
         )
 
         ranked = predict_and_print("\n🔄 Updated differential:") or ranked
+        engine.update_differential(ranked)
 
     return turns, ranked
 

--- a/phaita/triage/__init__.py
+++ b/phaita/triage/__init__.py
@@ -5,9 +5,11 @@ from .diagnosis import (
     format_differential_report,
 )
 from .info_sheet import format_info_sheet
+from .question_strategy import ExpectedInformationGainStrategy
 
 __all__ = [
     "enrich_differential_with_guidance",
     "format_differential_report",
     "format_info_sheet",
+    "ExpectedInformationGainStrategy",
 ]

--- a/phaita/triage/question_strategy.py
+++ b/phaita/triage/question_strategy.py
@@ -1,0 +1,111 @@
+"""Question selection heuristics driven by expected information gain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+from ..data.red_flags import RESPIRATORY_RED_FLAGS
+
+
+def _normalise(text: str) -> str:
+    return " ".join(text.lower().strip().split())
+
+
+@dataclass
+class ExpectedInformationGainStrategy:
+    """Rank candidate prompts using a heuristic information gain metric."""
+
+    red_flag_weight: float = 0.6
+    symptom_weight: float = 0.3
+    repeat_penalty: float = 0.5
+    novelty_floor: float = 0.15
+
+    def score_question(
+        self,
+        question: str,
+        differential: Sequence[dict],
+        conversation_history: Sequence[dict],
+    ) -> float:
+        """Compute expected information gain for a candidate question."""
+
+        if not question:
+            return 0.0
+
+        question_norm = _normalise(question)
+        asked = {_normalise(turn.get("question", "")) for turn in conversation_history}
+
+        if question_norm in asked:
+            return 0.0
+
+        base_uncertainty = 0.0
+        bonus = 0.0
+
+        for entry in differential or []:
+            probability = float(entry.get("probability", 0.0))
+            if probability <= 0.0:
+                continue
+
+            # Encourage exploration where predictive uncertainty remains.
+            base_uncertainty += probability * (1.0 - probability)
+
+            code = entry.get("condition_code")
+            evidence = entry.get("evidence", {})
+            keywords: List[str] = []
+
+            for symptom in evidence.get("key_symptoms", []) or []:
+                keywords.append(symptom.replace("_", " "))
+
+            for indicator in evidence.get("severity_indicators", []) or []:
+                keywords.append(indicator.replace("_", " "))
+
+            red_flag_bundle = RESPIRATORY_RED_FLAGS.get(code, {})
+            for flag in red_flag_bundle.get("symptoms", []) or []:
+                keywords.append(flag)
+
+            for keyword in keywords:
+                keyword_norm = _normalise(keyword)
+                if keyword_norm and keyword_norm in question_norm:
+                    weight = (
+                        self.red_flag_weight
+                        if keyword in red_flag_bundle.get("symptoms", [])
+                        else self.symptom_weight
+                    )
+                    bonus += weight * probability
+
+        # Scale base uncertainty by a novelty term so later turns naturally
+        # diminish their marginal value without red-flag reinforcement.
+        novelty_scale = 1.0 / (1.0 + max(len(conversation_history), 0))
+        novelty_scale = max(novelty_scale, self.novelty_floor)
+
+        info_gain = base_uncertainty * novelty_scale + bonus
+
+        if question_norm in {_normalise(turn.get("question", "")) for turn in conversation_history[-2:]}:
+            info_gain *= self.repeat_penalty
+
+        return info_gain
+
+    def select_question(
+        self,
+        candidates: Sequence[str],
+        differential: Optional[Sequence[dict]],
+        conversation_history: Sequence[dict],
+    ) -> Tuple[Optional[str], float]:
+        """Pick the question with the highest information gain score."""
+
+        best_question: Optional[str] = None
+        best_score = -1.0
+
+        for candidate in candidates:
+            score = self.score_question(candidate, differential or [], conversation_history)
+            if score > best_score:
+                best_question = candidate
+                best_score = score
+
+        if best_question is None:
+            return None, 0.0
+
+        return best_question, best_score if best_score > 0 else 0.0
+
+
+__all__ = ["ExpectedInformationGainStrategy"]

--- a/test_conversation_engine.py
+++ b/test_conversation_engine.py
@@ -1,27 +1,53 @@
-"""Tests for the conversation engine dialogue controller."""
+"""Regression tests for the conversation engine's triage flow."""
 
 from phaita.conversation.engine import ConversationEngine
 
 
 class SequenceGenerator:
-    """Stub question generator that cycles through predefined prompts."""
+    """Stub generator that yields a deterministic sequence of prompts."""
 
     def __init__(self, questions):
-        self.questions = questions
+        self.questions = list(questions)
         self.index = 0
 
-    def generate_clarifying_question(self, symptoms, **kwargs):
+    def generate_candidate_questions(self, symptoms, **kwargs):  # noqa: D401
         question = self.questions[self.index % len(self.questions)]
         self.index += 1
-        return question
+        return [question]
+
+    def generate_clarifying_question(self, symptoms, **kwargs):
+        return self.generate_candidate_questions(symptoms, **kwargs)[0]
 
 
 class HistoryAwareGenerator:
-    """Stub generator that ensures conversation history is provided."""
+    """Stub generator that inspects prior questions for variety."""
 
-    def generate_clarifying_question(self, symptoms, previous_questions=None, **kwargs):
-        previous_questions = previous_questions or []
-        return f"Follow-up {len(previous_questions) + 1}"
+    def __init__(self):
+        self.counter = 0
+
+    def generate_candidate_questions(self, symptoms, previous_questions=None, **kwargs):
+        self.counter += 1
+        label = previous_questions or []
+        return [f"Follow-up {len(label) + 1}"]
+
+    def generate_clarifying_question(self, symptoms, **kwargs):
+        return self.generate_candidate_questions(symptoms, **kwargs)[0]
+
+
+class CandidatePoolGenerator:
+    """Generator that exposes a precomputed pool of candidate prompts."""
+
+    def __init__(self, pools):
+        self.pools = list(pools)
+        self.index = 0
+
+    def generate_candidate_questions(self, symptoms, **kwargs):
+        pool = self.pools[self.index % len(self.pools)]
+        self.index += 1
+        return list(pool)
+
+    def generate_clarifying_question(self, symptoms, **kwargs):
+        return self.generate_candidate_questions(symptoms, **kwargs)[0]
 
 
 def test_conversation_progression_tracks_symptoms():
@@ -61,7 +87,12 @@ def test_conversation_avoids_repeating_questions():
 
 def test_conversation_termination_on_no_progress():
     generator = HistoryAwareGenerator()
-    engine = ConversationEngine(generator, max_questions=5, min_symptom_count=6, max_no_progress_turns=2)
+    engine = ConversationEngine(
+        generator,
+        max_questions=5,
+        min_symptom_count=6,
+        max_no_progress_turns=2,
+    )
     engine.add_symptoms(["cough"])
 
     prompt1 = engine.next_prompt()
@@ -74,3 +105,80 @@ def test_conversation_termination_on_no_progress():
 
     assert engine.should_present_diagnosis()
     assert engine.next_prompt() is None
+
+
+def test_engine_prioritises_red_flag_questions():
+    generator = CandidatePoolGenerator([
+        [
+            "Have you noticed bluish lips or fingernails recently?",
+            "When did your coughing episodes begin?",
+        ]
+    ])
+    engine = ConversationEngine(
+        generator,
+        max_questions=3,
+        min_symptom_count=5,
+        information_gain_threshold=0.01,
+    )
+    engine.add_symptoms(["cough"])
+
+    differential = [
+        {
+            "condition_code": "J45.9",
+            "probability": 0.7,
+            "evidence": {
+                "key_symptoms": ["wheezing"],
+                "severity_indicators": ["breathlessness at rest"],
+            },
+        }
+    ]
+    engine.update_differential(differential)
+
+    prompt = engine.next_prompt()
+
+    assert "bluish lips" in prompt.lower()
+    assert engine.information_gain_history and engine.information_gain_history[0] > 0
+
+
+def test_engine_information_gain_threshold_stops_loop():
+    generator = SequenceGenerator([
+        "Can you describe your breathing?",
+        "Do you have chest tightness?",
+        "Any other concerns?",
+    ])
+    engine = ConversationEngine(
+        generator,
+        max_questions=6,
+        min_symptom_count=5,
+        information_gain_threshold=0.05,
+    )
+    engine.add_symptoms(["cough"])
+
+    differential = [
+        {
+            "condition_code": "J06.9",
+            "probability": 0.5,
+            "evidence": {
+                "key_symptoms": ["cough"],
+                "severity_indicators": ["fever"],
+            },
+        }
+    ]
+
+    engine.update_differential(differential)
+
+    first = engine.next_prompt()
+    engine.record_response(first, "Nothing new", [])
+    engine.update_differential(differential)
+
+    second = engine.next_prompt()
+    engine.record_response(second, "Still nothing", [])
+    engine.update_differential(differential)
+
+    # The third call should stop due to diminishing information gain
+    third = engine.next_prompt()
+
+    assert third is None
+    assert engine.should_present_diagnosis()
+    assert engine.information_gain_history[-1] > 0
+    assert engine.last_info_gain_gradient is not None


### PR DESCRIPTION
## Summary
- add an ExpectedInformationGainStrategy that scores candidate questions with diagnosis probabilities and respiratory red-flag weighting
- extend the question generator and conversation engine to surface candidate pools, track information gain, and stop when marginal value falls below a threshold
- update the CLI workflow to refresh the differential for question selection and add regression tests for red-flag prioritisation and termination behaviour

## Testing
- pytest test_conversation_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68de9a94c54483239bbd9dc6e6735719