### PR TITLE
Externalize respiratory condition catalogue and sync vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,42 @@ python cli.py train --epochs 50 --batch-size 16
 python cli.py diagnose --complaint "I can't catch my breath"
 ```
 
+### Editing respiratory condition definitions
+
+Respiratory conditions, symptoms, severity indicators, and lay-language vocabularies
+now live in [`config/respiratory_conditions.yaml`](config/respiratory_conditions.yaml).
+Clinicians can edit this file (or point the `PHAITA_RESPIRATORY_CONFIG`
+environment variable at an alternative path) without touching the Python code.
+
+```yaml
+J45.9:
+  name: Asthma
+  symptoms:
+    - wheezing
+    - shortness_of_breath
+  severity_indicators:
+    - unable_to_speak
+  lay_terms:
+    - "can't breathe"
+    - tight chest
+  description: Chronic inflammatory airway disease with episodic symptoms
+```
+
+After editing the file, long-running services can hot-reload the catalogue:
+
+```python
+from phaita.data import RespiratoryConditions
+
+# Reload from disk (uses PHAITA_RESPIRATORY_CONFIG if set)
+RespiratoryConditions.reload()
+```
+
+`BayesianSymptomNetwork`, `SymptomGenerator`, and `ComplaintGenerator` subscribe to
+these reload events automatically, so freshly authored conditions become available
+immediately. Forum scraping and curriculum-learning utilities consume the same
+vocabulary via `RespiratoryConditions.get_vocabulary()`, ensuring the NLP complaint
+generator is trained on the exact symptom and lay-language set defined by physicians.
+
 ### Forum scraping
 Real forum data is now harvested on-demand via `scripts/scrape_forums.py`. The
 Reddit client uses OAuth credentials which must be supplied via environment

--- a/config/respiratory_conditions.yaml
+++ b/config/respiratory_conditions.yaml
@@ -1,0 +1,215 @@
+J45.9:
+  name: Asthma
+  symptoms:
+    - wheezing
+    - shortness_of_breath
+    - chest_tightness
+    - cough
+    - difficulty_breathing
+  severity_indicators:
+    - unable_to_speak
+    - cyanosis
+    - tachypnea
+    - use_of_accessory_muscles
+    - severe_distress
+  lay_terms:
+    - wheezy
+    - "can't breathe"
+    - tight chest
+    - "can't catch my breath"
+    - breathless
+    - gasping for air
+  description: Chronic inflammatory airway disease with episodic symptoms
+J18.9:
+  name: Pneumonia
+  symptoms:
+    - cough
+    - fever
+    - chest_pain
+    - dyspnea
+    - productive_cough
+    - fatigue
+  severity_indicators:
+    - high_fever
+    - severe_chest_pain
+    - confusion
+    - rapid_breathing
+    - low_oxygen
+  lay_terms:
+    - coughing up stuff
+    - chest hurts
+    - "can't breathe properly"
+    - really tired
+    - burning chest
+    - lung infection
+  description: Infection causing inflammation of lung tissue
+J44.9:
+  name: COPD
+  symptoms:
+    - chronic_cough
+    - dyspnea
+    - wheezing
+    - sputum_production
+    - chest_tightness
+  severity_indicators:
+    - severe_breathlessness
+    - cyanosis
+    - weight_loss
+    - edema
+    - barrel_chest
+  lay_terms:
+    - "can't breathe"
+    - constant cough
+    - bringing up phlegm
+    - out of breath
+    - chest feels tight
+  description: Chronic obstructive pulmonary disease with airflow limitation
+J06.9:
+  name: Upper respiratory infection
+  symptoms:
+    - sore_throat
+    - runny_nose
+    - cough
+    - sneezing
+    - nasal_congestion
+    - mild_fever
+  severity_indicators:
+    - high_fever
+    - severe_throat_pain
+    - difficulty_swallowing
+    - persistent_cough
+  lay_terms:
+    - stuffy nose
+    - scratchy throat
+    - head cold
+    - sniffles
+    - throat hurts
+  description: Common cold or upper respiratory tract infection
+J20.9:
+  name: Acute bronchitis
+  symptoms:
+    - cough
+    - sputum_production
+    - chest_discomfort
+    - mild_dyspnea
+    - wheezing
+  severity_indicators:
+    - persistent_cough
+    - blood_in_sputum
+    - fever
+    - severe_chest_pain
+  lay_terms:
+    - chest cold
+    - hacking cough
+    - coughing up mucus
+    - chest feels heavy
+    - "can't stop coughing"
+  description: Acute inflammation of bronchial tubes
+J81.0:
+  name: Acute pulmonary edema
+  symptoms:
+    - severe_dyspnea
+    - orthopnea
+    - cough
+    - wheezing
+    - anxiety
+    - pink_frothy_sputum
+  severity_indicators:
+    - extreme_breathlessness
+    - cyanosis
+    - confusion
+    - diaphoresis
+    - tachycardia
+  lay_terms:
+    - "can't breathe lying down"
+    - drowning feeling
+    - gasping for air
+    - fluid in lungs
+    - suffocating
+  description: Fluid accumulation in lung tissue
+J93.0:
+  name: Spontaneous tension pneumothorax
+  symptoms:
+    - sudden_chest_pain
+    - dyspnea
+    - tachycardia
+    - anxiety
+    - decreased_breath_sounds
+  severity_indicators:
+    - severe_chest_pain
+    - extreme_breathlessness
+    - hypotension
+    - cyanosis
+    - respiratory_distress
+  lay_terms:
+    - collapsed lung
+    - sharp chest pain
+    - sudden breathing trouble
+    - stabbing pain
+    - "can't take deep breath"
+  description: Air in pleural space causing lung collapse
+J15.9:
+  name: Bacterial pneumonia
+  symptoms:
+    - productive_cough
+    - fever
+    - chest_pain
+    - dyspnea
+    - chills
+    - fatigue
+  severity_indicators:
+    - high_fever
+    - confusion
+    - severe_chest_pain
+    - rapid_breathing
+    - hypoxia
+  lay_terms:
+    - lung infection
+    - coughing up colored mucus
+    - chest really hurts
+    - "can't breathe right"
+    - really sick
+  description: Bacterial infection of lung parenchyma
+J12.9:
+  name: Viral pneumonia
+  symptoms:
+    - dry_cough
+    - fever
+    - dyspnea
+    - myalgia
+    - headache
+    - fatigue
+  severity_indicators:
+    - high_fever
+    - severe_dyspnea
+    - confusion
+    - rapid_breathing
+  lay_terms:
+    - dry cough
+    - viral lung infection
+    - aching all over
+    - "can't breathe well"
+    - wiped out
+  description: Viral infection of lung tissue
+J21.9:
+  name: Acute bronchiolitis
+  symptoms:
+    - wheezing
+    - cough
+    - dyspnea
+    - tachypnea
+    - nasal_flaring
+    - retractions
+  severity_indicators:
+    - severe_respiratory_distress
+    - cyanosis
+    - apnea
+    - poor_feeding
+    - lethargy
+  lay_terms:
+    - "baby can't breathe"
+    - wheezing badly
+    - working hard to breathe
+    - breathing really fast
+    - chest pulling in
+  description: Inflammation of small airways, common in infants

--- a/phaita/data/icd_conditions.py
+++ b/phaita/data/icd_conditions.py
@@ -1,190 +1,190 @@
-"""
-ICD-10 respiratory conditions database with symptoms, severity indicators, and lay language mappings.
-Based on medical literature and clinical guidelines.
-"""
+"""Respiratory condition catalogue that loads from physician-editable config."""
 
+from __future__ import annotations
+
+import copy
+import os
 import random
-from typing import Dict, List, Tuple, Optional
+import threading
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+
+import yaml
 
 
 class RespiratoryConditions:
-    """
-    Database of 10 respiratory conditions with ICD-10 codes, symptoms, and lay terms.
-    """
-    
-    _CONDITIONS = {
-        "J45.9": {
-            "name": "Asthma",
-            "symptoms": [
-                "wheezing", "shortness_of_breath", "chest_tightness", 
-                "cough", "difficulty_breathing"
-            ],
-            "severity_indicators": [
-                "unable_to_speak", "cyanosis", "tachypnea", 
-                "use_of_accessory_muscles", "severe_distress"
-            ],
-            "lay_terms": [
-                "wheezy", "can't breathe", "tight chest", "can't catch my breath",
-                "breathless", "gasping for air"
-            ],
-            "description": "Chronic inflammatory airway disease with episodic symptoms"
-        },
-        "J18.9": {
-            "name": "Pneumonia",
-            "symptoms": [
-                "cough", "fever", "chest_pain", "dyspnea", 
-                "productive_cough", "fatigue"
-            ],
-            "severity_indicators": [
-                "high_fever", "severe_chest_pain", "confusion", 
-                "rapid_breathing", "low_oxygen"
-            ],
-            "lay_terms": [
-                "coughing up stuff", "chest hurts", "can't breathe properly",
-                "really tired", "burning chest", "lung infection"
-            ],
-            "description": "Infection causing inflammation of lung tissue"
-        },
-        "J44.9": {
-            "name": "COPD",
-            "symptoms": [
-                "chronic_cough", "dyspnea", "wheezing", "sputum_production",
-                "chest_tightness"
-            ],
-            "severity_indicators": [
-                "severe_breathlessness", "cyanosis", "weight_loss",
-                "edema", "barrel_chest"
-            ],
-            "lay_terms": [
-                "can't breathe", "constant cough", "bringing up phlegm",
-                "out of breath", "chest feels tight"
-            ],
-            "description": "Chronic obstructive pulmonary disease with airflow limitation"
-        },
-        "J06.9": {
-            "name": "Upper respiratory infection",
-            "symptoms": [
-                "sore_throat", "runny_nose", "cough", "sneezing",
-                "nasal_congestion", "mild_fever"
-            ],
-            "severity_indicators": [
-                "high_fever", "severe_throat_pain", "difficulty_swallowing",
-                "persistent_cough"
-            ],
-            "lay_terms": [
-                "stuffy nose", "scratchy throat", "head cold",
-                "sniffles", "throat hurts"
-            ],
-            "description": "Common cold or upper respiratory tract infection"
-        },
-        "J20.9": {
-            "name": "Acute bronchitis",
-            "symptoms": [
-                "cough", "sputum_production", "chest_discomfort",
-                "mild_dyspnea", "wheezing"
-            ],
-            "severity_indicators": [
-                "persistent_cough", "blood_in_sputum", "fever",
-                "severe_chest_pain"
-            ],
-            "lay_terms": [
-                "chest cold", "hacking cough", "coughing up mucus",
-                "chest feels heavy", "can't stop coughing"
-            ],
-            "description": "Acute inflammation of bronchial tubes"
-        },
-        "J81.0": {
-            "name": "Acute pulmonary edema",
-            "symptoms": [
-                "severe_dyspnea", "orthopnea", "cough", "wheezing",
-                "anxiety", "pink_frothy_sputum"
-            ],
-            "severity_indicators": [
-                "extreme_breathlessness", "cyanosis", "confusion",
-                "diaphoresis", "tachycardia"
-            ],
-            "lay_terms": [
-                "can't breathe lying down", "drowning feeling",
-                "gasping for air", "fluid in lungs", "suffocating"
-            ],
-            "description": "Fluid accumulation in lung tissue"
-        },
-        "J93.0": {
-            "name": "Spontaneous tension pneumothorax",
-            "symptoms": [
-                "sudden_chest_pain", "dyspnea", "tachycardia",
-                "anxiety", "decreased_breath_sounds"
-            ],
-            "severity_indicators": [
-                "severe_chest_pain", "extreme_breathlessness", "hypotension",
-                "cyanosis", "respiratory_distress"
-            ],
-            "lay_terms": [
-                "collapsed lung", "sharp chest pain", "sudden breathing trouble",
-                "stabbing pain", "can't take deep breath"
-            ],
-            "description": "Air in pleural space causing lung collapse"
-        },
-        "J15.9": {
-            "name": "Bacterial pneumonia",
-            "symptoms": [
-                "productive_cough", "fever", "chest_pain", "dyspnea",
-                "chills", "fatigue"
-            ],
-            "severity_indicators": [
-                "high_fever", "confusion", "severe_chest_pain",
-                "rapid_breathing", "hypoxia"
-            ],
-            "lay_terms": [
-                "lung infection", "coughing up colored mucus",
-                "chest really hurts", "can't breathe right", "really sick"
-            ],
-            "description": "Bacterial infection of lung parenchyma"
-        },
-        "J12.9": {
-            "name": "Viral pneumonia",
-            "symptoms": [
-                "dry_cough", "fever", "dyspnea", "myalgia",
-                "headache", "fatigue"
-            ],
-            "severity_indicators": [
-                "high_fever", "severe_dyspnea", "confusion",
-                "rapid_breathing"
-            ],
-            "lay_terms": [
-                "dry cough", "viral lung infection", "aching all over",
-                "can't breathe well", "wiped out"
-            ],
-            "description": "Viral infection of lung tissue"
-        },
-        "J21.9": {
-            "name": "Acute bronchiolitis",
-            "symptoms": [
-                "wheezing", "cough", "dyspnea", "tachypnea",
-                "nasal_flaring", "retractions"
-            ],
-            "severity_indicators": [
-                "severe_respiratory_distress", "cyanosis", "apnea",
-                "poor_feeding", "lethargy"
-            ],
-            "lay_terms": [
-                "baby can't breathe", "wheezing badly", "working hard to breathe",
-                "breathing really fast", "chest pulling in"
-            ],
-            "description": "Inflammation of small airways, common in infants"
-        }
-    }
-    
+    """Runtime-configurable database of respiratory conditions."""
+
+    _CONFIG_ENV_VAR = "PHAITA_RESPIRATORY_CONFIG"
+    _DEFAULT_CONFIG_FILENAME = "respiratory_conditions.yaml"
+
+    _lock = threading.RLock()
+    _CONDITIONS: Dict[str, Dict] = {}
+    _config_path: Path = Path(
+        os.getenv(
+            _CONFIG_ENV_VAR,
+            Path(__file__).resolve().parents[2]
+            / "config"
+            / _DEFAULT_CONFIG_FILENAME,
+        )
+    )
+    _reload_hooks: List[Callable[[Dict[str, Dict]], None]] = []
+
+    REQUIRED_FIELDS = {"name", "symptoms", "severity_indicators", "lay_terms"}
+
+    @classmethod
+    def get_config_path(cls) -> Path:
+        """Return the current config path used for loading conditions."""
+
+        return cls._config_path
+
+    @classmethod
+    def register_reload_hook(
+        cls, callback: Callable[[Dict[str, Dict]], None]
+    ) -> None:
+        """Register a callback that is invoked whenever the catalogue reloads."""
+
+        with cls._lock:
+            if callback not in cls._reload_hooks:
+                cls._reload_hooks.append(callback)
+
+    @classmethod
+    def unregister_reload_hook(
+        cls, callback: Callable[[Dict[str, Dict]], None]
+    ) -> None:
+        """Remove a previously registered reload callback."""
+
+        with cls._lock:
+            if callback in cls._reload_hooks:
+                cls._reload_hooks.remove(callback)
+
+    @classmethod
+    def _notify_reload(cls) -> None:
+        snapshot = copy.deepcopy(cls._CONDITIONS)
+        for callback in list(cls._reload_hooks):
+            try:
+                callback(snapshot)
+            except Exception:
+                # Hooks should not break reloading pipeline.
+                continue
+
+    @classmethod
+    def _resolve_config_path(cls, config_path: Optional[Path]) -> Path:
+        if config_path is not None:
+            return Path(config_path)
+        return Path(
+            os.getenv(
+                cls._CONFIG_ENV_VAR,
+                cls._config_path,
+            )
+        )
+
+    @classmethod
+    def _ensure_loaded(cls) -> None:
+        with cls._lock:
+            if not cls._CONDITIONS:
+                cls._load_conditions()
+
+    @classmethod
+    def _load_conditions(cls, *, config_path: Optional[Path] = None) -> None:
+        path = cls._resolve_config_path(config_path)
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Respiratory condition config not found at '{path}'."
+                " Set the PHAITA_RESPIRATORY_CONFIG environment variable or"
+                " call RespiratoryConditions.reload(config_path=...) with a valid file."
+            )
+
+        with path.open("r", encoding="utf-8") as handle:
+            raw_data = yaml.safe_load(handle) or {}
+
+        validated = cls._validate(raw_data)
+        cls._CONDITIONS = validated
+        cls._config_path = path
+
+    @classmethod
+    def _validate(cls, data: Mapping) -> Dict[str, Dict]:
+        if not isinstance(data, Mapping):
+            raise ValueError("Respiratory condition config must be a mapping of code -> data")
+
+        validated: Dict[str, Dict] = {}
+        for code, condition in data.items():
+            if not isinstance(code, str) or not code.strip():
+                raise ValueError("Condition codes must be non-empty strings")
+            if not isinstance(condition, Mapping):
+                raise ValueError(f"Condition '{code}' must be a mapping")
+
+            missing = cls.REQUIRED_FIELDS - set(condition.keys())
+            if missing:
+                raise ValueError(
+                    f"Condition '{code}' missing required fields: {sorted(missing)}"
+                )
+
+            validated_condition = {
+                "name": cls._validate_str(condition["name"], f"{code}.name"),
+                "symptoms": cls._validate_str_list(
+                    condition["symptoms"], f"{code}.symptoms"
+                ),
+                "severity_indicators": cls._validate_str_list(
+                    condition["severity_indicators"], f"{code}.severity_indicators"
+                ),
+                "lay_terms": cls._validate_str_list(
+                    condition["lay_terms"], f"{code}.lay_terms"
+                ),
+            }
+
+            if "description" in condition:
+                validated_condition["description"] = cls._validate_str(
+                    condition["description"], f"{code}.description"
+                )
+
+            validated[code] = validated_condition
+
+        if not validated:
+            raise ValueError("Respiratory condition config cannot be empty")
+
+        return validated
+
+    @staticmethod
+    def _validate_str(value: object, location: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{location} must be a non-empty string")
+        return value
+
+    @staticmethod
+    def _validate_str_list(value: object, location: str) -> List[str]:
+        if not isinstance(value, Iterable) or isinstance(value, (str, bytes)):
+            raise ValueError(f"{location} must be a list of strings")
+        result: List[str] = []
+        for item in value:
+            if not isinstance(item, str) or not item.strip():
+                raise ValueError(f"{location} entries must be non-empty strings")
+            result.append(item)
+        if not result:
+            raise ValueError(f"{location} must contain at least one entry")
+        return result
+
+    @classmethod
+    def reload(cls, *, config_path: Optional[Path] = None) -> Dict[str, Dict]:
+        """Reload the respiratory condition catalogue from disk."""
+
+        with cls._lock:
+            cls._load_conditions(config_path=config_path)
+            cls._notify_reload()
+            return copy.deepcopy(cls._CONDITIONS)
+
     @classmethod
     def get_all_conditions(cls) -> Dict[str, Dict]:
         """
         Get all respiratory conditions.
-        
+
         Returns:
             Dictionary mapping ICD-10 codes to condition data
         """
-        return cls._CONDITIONS.copy()
-    
+        cls._ensure_loaded()
+        return copy.deepcopy(cls._CONDITIONS)
+
     @classmethod
     def get_condition_by_code(cls, code: str) -> Dict:
         """
@@ -195,25 +195,27 @@ class RespiratoryConditions:
             
         Returns:
             Condition data dictionary
-            
+
         Raises:
             KeyError: If code not found
         """
+        cls._ensure_loaded()
         if code not in cls._CONDITIONS:
             raise KeyError(f"Condition code '{code}' not found")
-        return cls._CONDITIONS[code].copy()
-    
+        return copy.deepcopy(cls._CONDITIONS[code])
+
     @classmethod
     def get_random_condition(cls) -> Tuple[str, Dict]:
         """
         Get a random respiratory condition.
-        
+
         Returns:
             Tuple of (code, condition_data)
         """
+        cls._ensure_loaded()
         code = random.choice(list(cls._CONDITIONS.keys()))
-        return code, cls._CONDITIONS[code].copy()
-    
+        return code, copy.deepcopy(cls._CONDITIONS[code])
+
     @classmethod
     def get_symptoms_for_condition(cls, code: str) -> List[str]:
         """
@@ -250,8 +252,9 @@ class RespiratoryConditions:
         Returns:
             List of condition names
         """
+        cls._ensure_loaded()
         return [data["name"] for data in cls._CONDITIONS.values()]
-    
+
     @classmethod
     def search_by_symptom(cls, symptom: str) -> List[Tuple[str, Dict]]:
         """
@@ -263,9 +266,43 @@ class RespiratoryConditions:
         Returns:
             List of (code, condition_data) tuples
         """
+        cls._ensure_loaded()
         results = []
         for code, data in cls._CONDITIONS.items():
             all_symptoms = data["symptoms"] + data["severity_indicators"]
             if symptom in all_symptoms:
-                results.append((code, data.copy()))
+                results.append((code, copy.deepcopy(data)))
         return results
+
+    @classmethod
+    def get_vocabulary(cls, conditions: Optional[Dict[str, Dict]] = None) -> Dict[str, List[str]]:
+        """Return the canonical vocabulary derived from the condition catalogue."""
+
+        source = conditions or cls.get_all_conditions()
+        symptoms: List[str] = []
+        severity: List[str] = []
+        lay_terms: List[str] = []
+        condition_names: List[str] = []
+
+        for data in source.values():
+            symptoms.extend(data.get("symptoms", []))
+            severity.extend(data.get("severity_indicators", []))
+            lay_terms.extend(data.get("lay_terms", []))
+            condition_names.append(data.get("name", ""))
+
+        # Deduplicate while preserving order
+        def _unique(values: Iterable[str]) -> List[str]:
+            seen = set()
+            ordered: List[str] = []
+            for value in values:
+                if value not in seen:
+                    seen.add(value)
+                    ordered.append(value)
+            return ordered
+
+        return {
+            "symptoms": _unique(symptoms),
+            "severity_indicators": _unique(severity),
+            "lay_terms": _unique(lay_terms),
+            "condition_names": _unique(condition_names),
+        }

--- a/phaita/models/bayesian_network.py
+++ b/phaita/models/bayesian_network.py
@@ -1,9 +1,10 @@
-"""
-Bayesian symptom network for probabilistic symptom generation.
-"""
+"""Bayesian symptom network for probabilistic symptom generation."""
+
+from __future__ import annotations
 
 import random
-from typing import List, Dict, Tuple, Optional
+from typing import Dict, List, Optional
+
 from ..data.icd_conditions import RespiratoryConditions
 
 
@@ -11,11 +12,19 @@ class BayesianSymptomNetwork:
     """
     Bayesian network for modeling symptom relationships and generating realistic symptom sets.
     """
-    
-    def __init__(self):
+
+    def __init__(self, conditions: Optional[Dict[str, Dict]] = None):
         """Initialize the Bayesian symptom network."""
-        self.conditions = RespiratoryConditions.get_all_conditions()
-        
+        self.conditions: Dict[str, Dict] = {}
+        self.reload(conditions=conditions)
+
+    def reload(self, conditions: Optional[Dict[str, Dict]] = None) -> None:
+        """Refresh the network with the latest condition catalogue."""
+
+        if conditions is None:
+            conditions = RespiratoryConditions.get_all_conditions()
+        self.conditions = conditions
+
         # Probability parameters
         self.primary_symptom_prob = 0.8  # High probability for primary symptoms
         self.severity_symptom_prob = 0.4  # Lower for severity indicators

--- a/test_conditions_config.py
+++ b/test_conditions_config.py
@@ -1,0 +1,88 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from phaita.data.icd_conditions import RespiratoryConditions
+from phaita.data.forum_scraper import ForumDataAugmentation
+from phaita.models.generator import SymptomGenerator
+
+
+@pytest.fixture()
+def restore_default_config():
+    original_path = RespiratoryConditions.get_config_path()
+    try:
+        yield original_path
+    finally:
+        RespiratoryConditions.reload(config_path=original_path)
+
+
+def _write_config(path: Path, data: dict) -> Path:
+    with path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(data, handle)
+    return path
+
+
+def _minimal_condition(code: str = "X00.0") -> dict:
+    return {
+        code: {
+            "name": "Test Condition",
+            "symptoms": ["mystery_symptom"],
+            "severity_indicators": ["scary_indicator"],
+            "lay_terms": ["mystery illness"],
+            "description": "A configurable test condition",
+        }
+    }
+
+
+def test_reload_from_physician_config(tmp_path, restore_default_config):
+    config_path = _write_config(tmp_path / "resp.yaml", _minimal_condition())
+    hook_payloads = []
+
+    def _hook(data):
+        hook_payloads.append(json.loads(json.dumps(data)))
+
+    RespiratoryConditions.register_reload_hook(_hook)
+    try:
+        RespiratoryConditions.reload(config_path=config_path)
+        conditions = RespiratoryConditions.get_all_conditions()
+        assert "X00.0" in conditions
+        assert conditions["X00.0"]["name"] == "Test Condition"
+        vocabulary = RespiratoryConditions.get_vocabulary()
+        assert "mystery_symptom" in vocabulary["symptoms"]
+        assert hook_payloads, "Reload hook should be invoked"
+        assert "X00.0" in hook_payloads[-1]
+    finally:
+        RespiratoryConditions.unregister_reload_hook(_hook)
+
+
+def test_invalid_config_raises(tmp_path, restore_default_config):
+    invalid_config = {"BAD": {"name": "oops"}}
+    config_path = _write_config(tmp_path / "invalid.yaml", invalid_config)
+    with pytest.raises(ValueError):
+        RespiratoryConditions.reload(config_path=config_path)
+
+
+def test_forum_augmentation_uses_config_vocabulary(tmp_path, restore_default_config):
+    config = _minimal_condition()
+    config["X00.0"]["lay_terms"].append("rare phrase")
+    config_path = _write_config(tmp_path / "forum.yaml", config)
+    RespiratoryConditions.reload(config_path=config_path)
+    augmenter = ForumDataAugmentation(conditions=RespiratoryConditions.get_all_conditions())
+    complaints = augmenter.get_forum_complaints_for_pretraining(max_complaints=5)
+    assert any("rare phrase" in complaint for complaint in complaints)
+
+
+def test_symptom_generator_reloads_when_config_changes(tmp_path, restore_default_config):
+    first_config = _minimal_condition("X00.0")
+    first_path = _write_config(tmp_path / "first.yaml", first_config)
+    RespiratoryConditions.reload(config_path=first_path)
+    generator = SymptomGenerator()
+    assert "X00.0" in generator.bayesian_network.conditions
+
+    updated_config = _minimal_condition("X01.0")
+    updated_path = _write_config(tmp_path / "updated.yaml", updated_config)
+    RespiratoryConditions.reload(config_path=updated_path)
+    assert "X01.0" in generator.bayesian_network.conditions
+    assert "X00.0" not in generator.bayesian_network.conditions


### PR DESCRIPTION
## Summary
- move respiratory condition definitions into a physician-editable YAML file with runtime validation and reload hooks
- propagate dynamic condition data through the Bayesian symptom network, generators, and forum augmentation pipeline
- document the configuration workflow and add tests that exercise reload behaviour and shared vocabularies

## Testing
- pytest test_conditions_config.py test_basic.py

------
https://chatgpt.com/codex/tasks/task_e_68dedbc3db248323a783d9f6ad223ea0