### PR TITLE
Handle unlabeled forum complaints with entropy regularisation

### DIFF
--- a/IMPLEMENTATION_DETAILS.md
+++ b/IMPLEMENTATION_DETAILS.md
@@ -10,6 +10,7 @@ This note summarises how the deep-learning version of PHAITA differs from the li
 ## Training Loop Enhancements
 - Shared `AdversarialTrainer` handles alternating optimisation, gradient clipping, cosine learning-rate schedules, and curriculum sampling between synthetic and forum-style text.
 - Diversity, realism, and medical-consistency losses are combined with the adversarial objectives to stabilise training.
+- Curriculum mixing now returns a supervision mask so unlabeled forum complaints skip cross-entropy; their contribution is an entropy-minimisation term that regularises the discriminator without fabricating targets.
 
 ## Supporting Utilities
 - `phaita/utils/realism_scorer.py` scores complaints with transformer embeddings when available.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ The following models are automatically downloaded from HuggingFace Hub:
 |-------|------------|---------|
 | Complaint generation | Bayesian symptom sampler → Mistral-7B-Instruct (4-bit quantized) | Produce varied patient narratives for a target condition. |
 | Diagnosis | DeBERTa-v3-base encoder + Graph Attention Network (torch-geometric) | Predict condition and assess complaint realism. |
-| Training loop | AdversarialTrainer with curriculum and diversity losses | Alternate generator/discriminator optimization on synthetic + forum-style text. |
+| Training loop | AdversarialTrainer with curriculum, diversity, and unsupervised forum regularisation | Alternate generator/discriminator optimization on synthetic + forum-style text with masked unlabeled samples. |
+
+Curriculum batches now expose a boolean mask so unlabeled forum complaints skip
+cross-entropy updates. Instead, the discriminator minimises the entropy of its
+predictions on those samples, encouraging confident assignments without
+hallucinating random labels.
 
 ## Key Capabilities
 - **Synthetic-first pipeline**: Generates complaints, question prompts, and labeled datasets without patient data.


### PR DESCRIPTION
## Summary
- return a supervision mask from curriculum forum sampling so unlabeled complaints stop receiving random labels
- update the discriminator step to skip cross-entropy on masked complaints and apply an entropy regularisation term instead
- document the behaviour change and add a regression test that fails if random labels are generated for forum data

## Testing
- pytest test_adversarial_trainer_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68dee1b993e48323b0854b0b3c4fc6c8