### PR TITLE
Return logits from discriminator head

### DIFF
--- a/phaita/models/discriminator.py
+++ b/phaita/models/discriminator.py
@@ -139,8 +139,7 @@ class DiagnosisDiscriminator(nn.Module):
             nn.Linear(fusion_hidden_dim // 2, 128),
             nn.ReLU(),
             nn.Dropout(dropout),
-            nn.Linear(128, 1),
-            nn.Sigmoid()
+            nn.Linear(128, 1)
         )
         
         self.dropout = nn.Dropout(dropout)


### PR DESCRIPTION
## Summary
- remove the discriminator head sigmoid so adversarial training operates on logits
- extend the adversarial trainer tests to use logit-based dummy outputs and assert loss improvements

## Testing
- pytest test_adversarial_trainer_dataset.py -q

------
https://chatgpt.com/codex/tasks/task_e_68df03b0865883239c19eeb6a3a377ff