### PR TITLE
Handle comorbidity hints in challenge mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -603,20 +603,35 @@ def challenge_command(args):
             ("J44.1", ["heart_failure"]),
             ("J18.9", ["immunocompromised"])
         ]
-        
+
         for i, (condition, comorbidities) in enumerate(comorbidity_cases):
             symptoms, metadata = network.sample_symptoms(
                 condition,
-                comorbidities=comorbidities,
                 severity="moderate"
             )
-            
+
+            comorbidity_hints = [
+                f"history_of_{_normalize_symptom(comorbidity)}"
+                for comorbidity in comorbidities
+            ]
+            augmented_symptoms = list(dict.fromkeys(list(symptoms) + comorbidity_hints))
+
+            metadata = dict(metadata or {})
+            metadata["comorbidities"] = list(comorbidities)
+            if comorbidity_hints:
+                notes = list(metadata.get("notes", []))
+                notes.append(
+                    "Includes comorbidity cues: " + ", ".join(comorbidities)
+                )
+                metadata["notes"] = notes
+                metadata["comorbidity_hints"] = comorbidity_hints
+
             print(f"   {i+1}. {condition} with {', '.join(comorbidities)}")
             challenge_cases.append({
                 "type": "comorbidity",
                 "condition": condition,
                 "comorbidities": comorbidities,
-                "symptoms": symptoms,
+                "symptoms": augmented_symptoms,
                 "metadata": metadata
             })
         

--- a/test_cli_challenge_command.py
+++ b/test_cli_challenge_command.py
@@ -1,0 +1,77 @@
+from argparse import Namespace
+from types import SimpleNamespace
+
+import cli
+
+
+class _StubNetwork:
+    def __init__(self):
+        self.calls = []
+
+    def sample_symptoms(self, condition_code, **kwargs):
+        if "comorbidities" in kwargs:
+            raise AssertionError("comorbidities argument should not be passed")
+
+        self.calls.append((condition_code, dict(kwargs)))
+
+        metadata = {
+            "presentation_type": "rare" if kwargs.get("include_rare") else "standard",
+            "case_name": f"Case for {condition_code}",
+        }
+        metadata.setdefault("age_group", kwargs.get("age_group", "adult"))
+        metadata.setdefault("severity", kwargs.get("severity", "moderate"))
+
+        return [f"{condition_code}_symptom"], metadata
+
+
+class _StubComplaintGenerator:
+    def generate_complaint(self, condition_code, symptoms):
+        return SimpleNamespace(complaint_text=f"Complaint for {condition_code}")
+
+
+class _StubDiscriminator:
+    def predict_diagnosis(self, transcripts, top_k=3):
+        return [[{"condition_code": "J45.9", "probability": 0.5}]]
+
+
+class _StubEngine:
+    def __init__(self, *args, **kwargs):
+        self._symptoms = []
+
+    def add_symptoms(self, symptoms):
+        self._symptoms.extend(symptoms)
+
+    def update_differential(self, ranked):
+        return None
+
+    def should_present_diagnosis(self):
+        return True
+
+    def next_prompt(self):
+        return None
+
+    def record_response(self, prompt, response, extracted_symptoms):
+        return None
+
+
+def test_challenge_command_handles_comorbidity_cases(monkeypatch, capsys):
+    stub_network = _StubNetwork()
+
+    monkeypatch.setattr(cli, "create_enhanced_bayesian_network", lambda: stub_network)
+    monkeypatch.setattr(cli, "_get_complaint_generator", lambda: _StubComplaintGenerator())
+    monkeypatch.setattr(cli, "_get_diagnosis_discriminator", lambda: _StubDiscriminator())
+    monkeypatch.setattr(cli, "ConversationEngine", _StubEngine)
+    monkeypatch.setattr(cli, "_build_question_generator", lambda: object())
+
+    args = Namespace(
+        rare_cases=1,
+        atypical_cases=1,
+        show_failures=False,
+        verbose=False,
+    )
+
+    cli.challenge_command(args)
+
+    assert len(stub_network.calls) >= 3
+    assert all("comorbidities" not in kwargs for _, kwargs in stub_network.calls)
+


### PR DESCRIPTION
## Summary
- update the challenge command to augment comorbidity scenarios without passing unsupported keyword arguments
- add metadata and symptom cues for comorbidity-driven cases
- cover the challenge workflow with a focused unit test to ensure the command executes successfully

## Testing
- pytest test_cli_challenge_command.py

------
https://chatgpt.com/codex/tasks/task_e_68df44df2f008323b40c9ccf9d90733e