### PR TITLE
Add pytest dependency to align local and pip installs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ safetensors>=0.3.0
 praw>=7.7.0
 requests>=2.31.0
 beautifulsoup4>=4.12.0
+pytest>=7.0
 
 # Optional for advanced GNN features
 # torch-scatter>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "praw>=7.7.0",
         "requests>=2.31.0",
         "beautifulsoup4>=4.12.0",
+        "pytest>=7.0",
     ],
     python_requires=">=3.8",
 )


### PR DESCRIPTION
## Summary
- add pytest to requirements.txt so local installs include the test runner
- mirror the pytest dependency in setup.py install_requires for consistency

## Testing
- pip install -e .
- python -m pytest tests/test_conditions_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e0986640d48323844432609023796e