### PR TITLE
Remove sys.path hacks and document editable installs

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2,6 +2,9 @@
 """
 PHAITA CLI - Command line interface for Pre-Hospital AI Triage Algorithm
 Enhanced with user diagnosis testing and adversarial challenge mode.
+
+Install the project in editable mode (``pip install -e .``) before running the
+CLI so that ``phaita`` can be imported without manual path modifications.
 """
 
 import argparse
@@ -11,10 +14,6 @@ import random
 import sys
 import textwrap
 from functools import lru_cache
-from pathlib import Path
-
-# Add the package to Python path
-sys.path.insert(0, str(Path(__file__).parent))
 
 from phaita import (
     AdversarialTrainer,

--- a/demos/demo_causal_edges.py
+++ b/demos/demo_causal_edges.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 #!/usr/bin/env python3
 """
 Demo script showing causal edges in the symptom graph.

--- a/demos/demo_comorbidity.py
+++ b/demos/demo_comorbidity.py
@@ -9,11 +9,7 @@ This demo shows how comorbidities affect symptom presentations, including:
 4. Cross-condition interactions (e.g., Asthma + COPD = ACOS)
 """
 
-import sys
-from pathlib import Path
 
-# Add the package to Python path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from phaita.models.enhanced_bayesian_network import create_enhanced_bayesian_network
 

--- a/demos/demo_deep_learning.py
+++ b/demos/demo_deep_learning.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 #!/usr/bin/env python3
 """
 Demo script for PHAITA deep learning models.

--- a/demos/demo_diagnosis_orchestrator.py
+++ b/demos/demo_diagnosis_orchestrator.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 """
 Demo for the Diagnosis Orchestrator with Red-Flag Integration.
 

--- a/demos/demo_dialogue_engine.py
+++ b/demos/demo_dialogue_engine.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 #!/usr/bin/env python3
 """Demo script showing the DialogueEngine with Bayesian belief updating in action."""
 

--- a/demos/demo_fixes.py
+++ b/demos/demo_fixes.py
@@ -4,11 +4,7 @@ Demo script showcasing the critical bug fixes in PHAITA.
 Demonstrates all four tasks working together.
 """
 
-import sys
-from pathlib import Path
 
-# Add package to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from phaita.training.adversarial_trainer import AdversarialTrainer
 from phaita.models.generator import SymptomGenerator, ComplaintGenerator

--- a/demos/demo_model_loader.py
+++ b/demos/demo_model_loader.py
@@ -4,11 +4,7 @@ Demo script showing the robust model loader in action.
 This demonstrates the retry mechanism, offline mode, and error handling.
 """
 
-import sys
-from pathlib import Path
 
-# Add package to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from phaita.utils.model_loader import (
     robust_model_download,

--- a/demos/demo_temporal_modeling.py
+++ b/demos/demo_temporal_modeling.py
@@ -6,12 +6,9 @@ This demonstrates how the temporal module tracks symptom progression
 and uses pattern matching to improve diagnosis accuracy.
 """
 
-import sys
 from pathlib import Path
 import importlib.util
 
-# Add package to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Import temporal module directly to avoid __init__ dependency issues
 def import_temporal_module():

--- a/demos/demo_uncertainty.py
+++ b/demos/demo_uncertainty.py
@@ -4,11 +4,7 @@ Demonstration of the uncertainty quantification implementation.
 This demo shows the API and expected behavior without requiring model downloads.
 """
 
-import sys
-from pathlib import Path
 
-# Add the package to Python path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 def demo_uncertainty_api():

--- a/demos/simple_demo.py
+++ b/demos/simple_demo.py
@@ -4,11 +4,7 @@ Simple demo script for PHAITA without heavy dependencies.
 Shows the data layer and basic functionality.
 """
 
-import sys
-from pathlib import Path
 
-# Add the package to Python path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from phaita.data.icd_conditions import RespiratoryConditions
 import random

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -555,6 +555,10 @@ When adding new tests to PHAITA:
 
 ### Example Test Structure
 
+Install the repository in editable mode (``pip install -e .``) before running
+tests locally. This makes the ``phaita`` package importable without modifying
+``sys.path`` in each file.
+
 ```python
 #!/usr/bin/env python3
 """
@@ -562,32 +566,30 @@ Test script for <feature>.
 <Brief description of what this test validates>
 """
 
-import sys
-from pathlib import Path
+from phaita.example import some_dependency
 
-# Add package to path
-sys.path.insert(0, str(Path(__file__).parent))
 
 def test_feature_one():
     """Test <specific aspect>."""
     print("🧪 Testing <aspect>...")
-    
+
     # Test logic here
     assert condition, "Clear failure message"
-    
+
     print("  ✓ <what passed>")
     return True
+
 
 def main():
     """Run all tests."""
     print("🏥 PHAITA <Feature> Test Suite")
     print("=" * 60)
-    
+
     tests = [
         ("Feature One", test_feature_one),
         ("Feature Two", test_feature_two),
     ]
-    
+
     passed = 0
     for name, test_fn in tests:
         try:
@@ -596,10 +598,10 @@ def main():
                 passed += 1
         except Exception as e:
             print(f"❌ {name} failed: {e}")
-    
+
     print("=" * 60)
     print(f"📊 Test Results: {passed}/{len(tests)} tests passed")
-    
+
     if passed == len(tests):
         print("🎉 All tests passed!")
         return 0
@@ -607,8 +609,9 @@ def main():
         print("❌ Some tests failed!")
         return 1
 
+
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())
 ```
 
 ## Related Documentation

--- a/patient_cli.py
+++ b/patient_cli.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
-"""Interactive CLI for the patient simulator."""
+"""Interactive CLI for the patient simulator.
+
+Install the project in editable mode (``pip install -e .``) before running the
+CLI so that ``phaita`` imports resolve without manual path tweaks.
+"""
 
 from __future__ import annotations
 
 import argparse
 import random
-import sys
 from dataclasses import dataclass
-from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
-
-# Ensure the package can be imported when running from the repository root
-sys.path.insert(0, str(Path(__file__).parent))
 
 from phaita.data.icd_conditions import RespiratoryConditions
 from phaita.generation.patient_agent import PatientPresentation, PatientSimulator

--- a/scripts/profile_gnn.py
+++ b/scripts/profile_gnn.py
@@ -2,15 +2,14 @@
 """
 Profile GNN forward pass performance using torch.profiler.
 Identifies bottlenecks and saves detailed profiling results.
+
+Install the project in editable mode (``pip install -e .``) before running this
+script so that ``phaita`` imports resolve without manual path adjustments.
 """
 
 import os
-import sys
 import torch
 from torch.profiler import profile, ProfilerActivity, record_function
-
-# Add parent directory to path for imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from phaita.data.icd_conditions import RespiratoryConditions
 from phaita.models.gnn_module import SymptomGraphModule

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     version="0.1.0",
     description="Pre-Hospital AI Triage Algorithm with Adversarial Training",
     packages=find_packages(),
+    py_modules=["cli", "patient_cli"],
     install_requires=read_requirements(),
     python_requires=">=3.8",
 )

--- a/tests/test_adversarial_trainer_dataset.py
+++ b/tests/test_adversarial_trainer_dataset.py
@@ -1,6 +1,4 @@
 import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import importlib
 import sys

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,11 +9,8 @@ For tests requiring real models, see test_integration.py.
 """
 
 import sys
-from pathlib import Path
 import traceback
 
-# Add the package to Python path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 def test_data_layer():

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -6,10 +6,7 @@ Tests causal edges, temporal edges, and edge type embeddings.
 
 import sys
 import torch
-from pathlib import Path
 
-# Add the package to Python path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from phaita.data.icd_conditions import RespiratoryConditions
 from phaita.models.gnn_module import SymptomGraphBuilder, SymptomGraphModule

--- a/tests/test_cli_challenge_command.py
+++ b/tests/test_cli_challenge_command.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 from argparse import Namespace
 from types import SimpleNamespace
 

--- a/tests/test_cli_triage_workflow.py
+++ b/tests/test_cli_triage_workflow.py
@@ -1,6 +1,4 @@
 import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from types import SimpleNamespace as Namespace
 from unittest.mock import MagicMock, patch

--- a/tests/test_conditions_config.py
+++ b/tests/test_conditions_config.py
@@ -1,6 +1,4 @@
-import sys
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import json
 from pathlib import Path

--- a/tests/test_conversation_engine.py
+++ b/tests/test_conversation_engine.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 """Regression tests for the conversation engine's triage flow.
 
 Note: This test suite uses stub generators and does NOT require real transformer models.

--- a/tests/test_conversation_flow.py
+++ b/tests/test_conversation_flow.py
@@ -1,6 +1,4 @@
 import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 """Comprehensive integration tests for multi-turn dialogue triage sessions.
 

--- a/tests/test_diagnosis_orchestrator.py
+++ b/tests/test_diagnosis_orchestrator.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 """Tests for the diagnosis orchestrator with red-flag integration."""
 
 from phaita.triage.diagnosis_orchestrator import DiagnosisOrchestrator, DiagnosisWithContext

--- a/tests/test_dialogue_engine.py
+++ b/tests/test_dialogue_engine.py
@@ -1,6 +1,4 @@
 import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 """Tests for the dialogue engine with Bayesian belief updating."""
 

--- a/tests/test_discriminator_lite.py
+++ b/tests/test_discriminator_lite.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 """Test lightweight discriminator functionality."""
 
 from phaita.models.discriminator_lite import LightweightDiscriminator, VocabularyFeatureExtractor

--- a/tests/test_end_to_end_triage.py
+++ b/tests/test_end_to_end_triage.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 """End-to-end integration test for complete triage workflow.
 
 Simulates: Patient complaint → Dialogue questions → Final diagnosis → Escalation guidance

--- a/tests/test_enhanced_bayesian.py
+++ b/tests/test_enhanced_bayesian.py
@@ -4,10 +4,7 @@ Test enhanced Bayesian network functionality.
 """
 
 import sys
-from pathlib import Path
 
-# Add the package to Python path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 def test_enhanced_bayesian_network():
     """Test enhanced Bayesian network functionality."""

--- a/tests/test_escalation_guidance.py
+++ b/tests/test_escalation_guidance.py
@@ -1,6 +1,4 @@
 import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 """Comprehensive tests for escalation guidance and routing.
 

--- a/tests/test_forum_scraping.py
+++ b/tests/test_forum_scraping.py
@@ -4,12 +4,9 @@ Test forum scraping and lay language mapping functionality.
 """
 
 import sys
-from pathlib import Path
 import tempfile
 import shutil
 
-# Add the package to Python path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 def test_forum_scraper():
     """Test forum scraping functionality."""

--- a/tests/test_gnn_performance.py
+++ b/tests/test_gnn_performance.py
@@ -1,6 +1,4 @@
 import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 #!/usr/bin/env python3
 """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,13 +11,10 @@ For lightweight tests that don't require models, see test_basic.py and test_conv
 """
 
 import json
-import sys
 import tempfile
 from datetime import datetime
 from pathlib import Path
 
-# Add package to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from phaita.training.adversarial_trainer import AdversarialTrainer
 from phaita.models.generator import SymptomGenerator, ComplaintGenerator

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -3,14 +3,11 @@ Test suite for robust model loader with retry mechanisms.
 Tests retry logic, exponential backoff, offline mode, and error handling.
 """
 
-import sys
 import time
-from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from phaita.utils.model_loader import (  # noqa: E402
     ModelDownloadError,

--- a/tests/test_normalization_fix.py
+++ b/tests/test_normalization_fix.py
@@ -1,6 +1,4 @@
 import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 #!/usr/bin/env python3
 """Test that demonstrates the fix for inconsistent symptom naming.

--- a/tests/test_patient_cli.py
+++ b/tests/test_patient_cli.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 from patient_cli import ConversationIO, run_interview
 
 

--- a/tests/test_patient_simulation.py
+++ b/tests/test_patient_simulation.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 import random
 
 import pytest

--- a/tests/test_template_diversity.py
+++ b/tests/test_template_diversity.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 """
 Comprehensive tests for template diversity and quality.
 

--- a/tests/test_temporal_modeling.py
+++ b/tests/test_temporal_modeling.py
@@ -9,8 +9,6 @@ from pathlib import Path
 import traceback
 import importlib.util
 
-# Add the package to Python path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 def import_module_from_file(module_name, file_path):

--- a/tests/test_triage_differential.py
+++ b/tests/test_triage_differential.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 """Tests for triage differential formatting and guidance."""
 
 from phaita.models.discriminator import DiagnosisDiscriminator

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 #!/usr/bin/env python3
 """Test uncertainty quantification in discriminator."""
 

--- a/tests/verify_normalization.py
+++ b/tests/verify_normalization.py
@@ -1,6 +1,4 @@
 import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 #!/usr/bin/env python3
 """Verification script for symptom normalization across all modules.


### PR DESCRIPTION
## Summary
- remove manual `sys.path.insert` workarounds from demos and tests so they import `phaita` normally
- document editable installs in docs and CLI entry points and expose the CLI modules via `setup.py`
- update scripts to rely on the installed package instead of modifying `sys.path`

## Testing
- `pip install -e .`
- `pytest` *(fails: huggingface.co download blocked while loading dummy/model)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a69c3d40832398c4a061cc4b8825