### PR TITLE
Refine question generator error handling

### DIFF
--- a/phaita/models/question_generator.py
+++ b/phaita/models/question_generator.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Set
 import random
 import torch
 import torch.nn as nn
+from requests.exceptions import HTTPError
 from ..utils.model_loader import load_model_and_tokenizer, ModelDownloadError
 from ..utils.config import ModelConfig
 
@@ -139,7 +140,7 @@ class QuestionGenerator(nn.Module):
                 f"- CUDA GPU with 4GB+ VRAM recommended (CPU mode available with use_4bit=False)\n"
                 f"- Internet connection to download model from HuggingFace Hub"
             ) from e
-        except Exception as e:
+        except (OSError, ValueError, HTTPError) as e:
             raise RuntimeError(
                 f"Failed to load model {model_name}. "
                 f"Error: {e}\n"

--- a/tests/test_question_generator.py
+++ b/tests/test_question_generator.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from phaita.models.question_generator import QuestionGenerator
+from phaita.utils.model_loader import ModelDownloadError
+
+
+def test_question_generator_download_error_message(monkeypatch):
+    """Known download failures surface a helpful runtime error."""
+
+    def _raise_download_error(*args, **kwargs):
+        raise ModelDownloadError("network unreachable")
+
+    monkeypatch.setattr(
+        "phaita.models.question_generator.load_model_and_tokenizer",
+        _raise_download_error,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        QuestionGenerator(model_name="fake/model", use_4bit=False)
+
+    message = str(exc_info.value)
+    assert "Failed to load model fake/model" in message
+    assert "network unreachable" in message
+
+
+def test_question_generator_unexpected_error_propagates(monkeypatch):
+    """Unexpected errors are not masked by the runtime wrapper."""
+
+    class UnexpectedError(RuntimeError):
+        pass
+
+    def _raise_unexpected_error(*args, **kwargs):
+        raise UnexpectedError("boom")
+
+    monkeypatch.setattr(
+        "phaita.models.question_generator.load_model_and_tokenizer",
+        _raise_unexpected_error,
+    )
+
+    with pytest.raises(UnexpectedError):
+        QuestionGenerator(model_name="fake/model", use_4bit=False)


### PR DESCRIPTION
## Summary
- tighten QuestionGenerator error handling to only wrap expected download failures and import HTTPError
- ensure unexpected exceptions bubble up while maintaining the user-facing runtime message for download issues
- add unit tests that simulate download and unexpected errors when loading the model

## Testing
- pytest tests/test_question_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ae23dca08323b46d857f0c0dd6a2