### PR TITLE
Refactor dependency requirement messaging

### DIFF
--- a/phaita/models/discriminator.py
+++ b/phaita/models/discriminator.py
@@ -16,6 +16,11 @@ import torch.nn.functional as F
 
 from ..data.icd_conditions import RespiratoryConditions
 from ..utils.model_loader import load_model_and_tokenizer, ModelDownloadError
+from ..utils.dependency_versions import (
+    TRANSFORMERS_VERSION,
+    format_install_instruction,
+    format_transformer_requirements,
+)
 from .discriminator_lite import VocabularyFeatureExtractor
 
 # Optional dependencies are imported lazily to avoid heavy requirements when
@@ -81,7 +86,7 @@ class DiagnosisDiscriminator(nn.Module):
             except ImportError as e:
                 raise ImportError(
                     "transformers is required when use_pretrained=True. "
-                    "Install with: pip install transformers==4.46.0\n"
+                    f"{format_install_instruction('transformers', TRANSFORMERS_VERSION)}\n"
                     "GPU Requirements: CUDA-capable GPU with 4GB+ VRAM recommended for full functionality. "
                     "CPU-only mode available but slower."
                 ) from e
@@ -100,22 +105,22 @@ class DiagnosisDiscriminator(nn.Module):
                     for param in self.text_encoder.parameters():
                         param.requires_grad = False
             except ModelDownloadError as e:
+                requirements = format_transformer_requirements(
+                    internet_note="- Internet connection to download model from HuggingFace Hub"
+                )
                 raise RuntimeError(
                     f"Failed to load text encoder {model_name}. "
                     f"{e}\n"
-                    f"Requirements:\n"
-                    f"- transformers==4.46.0\n"
-                    f"- torch==2.5.1\n"
-                    f"- Internet connection to download model from HuggingFace Hub"
+                    f"{requirements}"
                 ) from e
             except Exception as e:
+                requirements = format_transformer_requirements(
+                    internet_note="- Internet connection to download model from HuggingFace Hub"
+                )
                 raise RuntimeError(
                     f"Failed to load text encoder {model_name}. "
                     f"Error: {e}\n"
-                    f"Requirements:\n"
-                    f"- transformers==4.46.0\n"
-                    f"- torch==2.5.1\n"
-                    f"- Internet connection to download model from HuggingFace Hub"
+                    f"{requirements}"
                 ) from e
 
             # Initialize GNN for symptom relationships lazily

--- a/phaita/models/generator.py
+++ b/phaita/models/generator.py
@@ -14,6 +14,11 @@ from ..data.icd_conditions import RespiratoryConditions
 from ..data.template_loader import TemplateManager
 from ..utils.model_loader import load_model_and_tokenizer, ModelDownloadError
 from ..utils.config import ModelConfig
+from ..utils.dependency_versions import (
+    TRANSFORMERS_VERSION,
+    format_install_instruction,
+    format_transformer_requirements,
+)
 from ..generation.patient_agent import (
     PatientDemographics,
     PatientHistory,
@@ -28,7 +33,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "transformers is required for ComplaintGenerator. "
-        "Install with: pip install transformers==4.46.0\n"
+        f"{format_install_instruction('transformers', TRANSFORMERS_VERSION)}\n"
         "GPU Requirements: CUDA-capable GPU with 4GB+ VRAM recommended for full functionality. "
         "CPU-only mode available but slower."
     ) from e
@@ -218,26 +223,26 @@ class ComplaintGenerator(nn.Module):
             self.model.eval()
             print(f"✓ Loaded {model_name} successfully")
         except ModelDownloadError as e:
+            requirements = format_transformer_requirements(
+                include_bitsandbytes=True,
+                include_cuda_note=True,
+                internet_note="- Internet connection to download model from HuggingFace Hub",
+            )
             raise RuntimeError(
                 f"Failed to load model {model_name}. "
                 f"{e}\n"
-                f"Requirements:\n"
-                f"- transformers==4.46.0\n"
-                f"- bitsandbytes==0.44.1 (for 4-bit quantization)\n"
-                f"- torch==2.5.1\n"
-                f"- CUDA GPU with 4GB+ VRAM recommended (CPU mode available with use_4bit=False)\n"
-                f"- Internet connection to download model from HuggingFace Hub"
+                f"{requirements}"
             ) from e
         except Exception as e:
+            requirements = format_transformer_requirements(
+                include_bitsandbytes=True,
+                include_cuda_note=True,
+                internet_note="- Internet connection to download model from HuggingFace Hub",
+            )
             raise RuntimeError(
                 f"Failed to load model {model_name}. "
                 f"Error: {e}\n"
-                f"Requirements:\n"
-                f"- transformers==4.46.0\n"
-                f"- bitsandbytes==0.44.1 (for 4-bit quantization)\n"
-                f"- torch==2.5.1\n"
-                f"- CUDA GPU with 4GB+ VRAM recommended (CPU mode available with use_4bit=False)\n"
-                f"- Internet connection to download model from HuggingFace Hub"
+                f"{requirements}"
             ) from e
     
     def _create_prompt(self, presentation: PatientPresentation) -> str:

--- a/phaita/models/question_generator.py
+++ b/phaita/models/question_generator.py
@@ -11,6 +11,11 @@ import torch.nn as nn
 from requests.exceptions import HTTPError
 from ..utils.model_loader import load_model_and_tokenizer, ModelDownloadError
 from ..utils.config import ModelConfig
+from ..utils.dependency_versions import (
+    TRANSFORMERS_VERSION,
+    format_install_instruction,
+    format_transformer_requirements,
+)
 
 # Enforce required dependencies
 try:
@@ -18,7 +23,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "transformers is required for QuestionGenerator. "
-        "Install with: pip install transformers==4.46.0\n"
+        f"{format_install_instruction('transformers', TRANSFORMERS_VERSION)}\n"
         "GPU Requirements: CUDA-capable GPU with 4GB+ VRAM recommended for full functionality. "
         "CPU-only mode available but slower."
     ) from e
@@ -130,26 +135,26 @@ class QuestionGenerator(nn.Module):
             self.model.eval()
             print(f"✓ Loaded {model_name} successfully")
         except ModelDownloadError as e:
+            requirements = format_transformer_requirements(
+                include_bitsandbytes=True,
+                include_cuda_note=True,
+                internet_note="- Internet connection to download model from HuggingFace Hub",
+            )
             raise RuntimeError(
                 f"Failed to load model {model_name}. "
                 f"{e}\n"
-                f"Requirements:\n"
-                f"- transformers==4.46.0\n"
-                f"- bitsandbytes==0.44.1 (for 4-bit quantization)\n"
-                f"- torch==2.5.1\n"
-                f"- CUDA GPU with 4GB+ VRAM recommended (CPU mode available with use_4bit=False)\n"
-                f"- Internet connection to download model from HuggingFace Hub"
+                f"{requirements}"
             ) from e
         except (OSError, ValueError, HTTPError) as e:
+            requirements = format_transformer_requirements(
+                include_bitsandbytes=True,
+                include_cuda_note=True,
+                internet_note="- Internet connection to download model from HuggingFace Hub",
+            )
             raise RuntimeError(
                 f"Failed to load model {model_name}. "
                 f"Error: {e}\n"
-                f"Requirements:\n"
-                f"- transformers==4.46.0\n"
-                f"- bitsandbytes==0.44.1 (for 4-bit quantization)\n"
-                f"- torch==2.5.1\n"
-                f"- CUDA GPU with 4GB+ VRAM recommended (CPU mode available with use_4bit=False)\n"
-                f"- Internet connection to download model from HuggingFace Hub"
+                f"{requirements}"
             ) from e
     
     def _create_question_prompt(

--- a/phaita/utils/dependency_versions.py
+++ b/phaita/utils/dependency_versions.py
@@ -1,0 +1,76 @@
+"""Central definitions for dependency versions and helper utilities."""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+TRANSFORMERS_VERSION = "4.46.0"
+BITSANDBYTES_VERSION = "0.44.1"
+TORCH_VERSION = "2.5.1"
+
+
+def _collect_requirement_lines(
+    include_bitsandbytes: bool,
+    include_cuda_note: bool,
+    internet_note: str | None,
+    extra_lines: Sequence[str] | None,
+) -> List[str]:
+    lines = [f"- transformers=={TRANSFORMERS_VERSION}"]
+
+    if include_bitsandbytes:
+        lines.append(
+            f"- bitsandbytes=={BITSANDBYTES_VERSION} (for 4-bit quantization)"
+        )
+
+    lines.append(f"- torch=={TORCH_VERSION}")
+
+    if include_bitsandbytes and include_cuda_note:
+        lines.append(
+            "- CUDA GPU with 4GB+ VRAM recommended (CPU mode available with use_4bit=False)"
+        )
+
+    if internet_note:
+        lines.append(internet_note)
+
+    if extra_lines:
+        lines.extend(extra_lines)
+
+    return lines
+
+
+def format_transformer_requirements(
+    *,
+    include_bitsandbytes: bool = False,
+    include_cuda_note: bool = False,
+    internet_note: str | None = "- Internet connection to download model(s) from HuggingFace Hub",
+    extra_lines: Sequence[str] | None = None,
+) -> str:
+    """Return a formatted requirements message for transformer-based modules.
+
+    Args:
+        include_bitsandbytes: Whether to include the bitsandbytes dependency line.
+        include_cuda_note: Whether to include the CUDA guidance line when
+            bitsandbytes is required.
+        internet_note: Custom text for the HuggingFace connectivity guidance. Set
+            to ``None`` to omit the line entirely.
+        extra_lines: Optional iterable of additional requirement lines.
+
+    Returns:
+        A newline-separated string beginning with ``"Requirements:"`` followed
+        by bullet points of dependencies.
+    """
+
+    requirement_lines = _collect_requirement_lines(
+        include_bitsandbytes=include_bitsandbytes,
+        include_cuda_note=include_cuda_note,
+        internet_note=internet_note,
+        extra_lines=extra_lines,
+    )
+
+    return "\n".join(["Requirements:", *requirement_lines])
+
+
+def format_install_instruction(package: str, version: str) -> str:
+    """Create a consistent ``pip install`` instruction string."""
+
+    return f"Install with: pip install {package}=={version}"

--- a/phaita/utils/model_loader.py
+++ b/phaita/utils/model_loader.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Optional, Union, Tuple, Any
 import hashlib
 
+from .dependency_versions import TRANSFORMERS_VERSION, format_install_instruction
+
 try:
     from transformers import (
         AutoTokenizer,
@@ -22,7 +24,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "transformers is required for model_loader. "
-        "Install with: pip install transformers==4.46.0"
+        f"{format_install_instruction('transformers', TRANSFORMERS_VERSION)}"
     ) from e
 
 try:

--- a/phaita/utils/realism_scorer.py
+++ b/phaita/utils/realism_scorer.py
@@ -12,6 +12,11 @@ import numpy as np
 from typing import List, Dict, Optional, Tuple
 import logging
 from .model_loader import robust_model_download, ModelDownloadError
+from .dependency_versions import (
+    TRANSFORMERS_VERSION,
+    format_install_instruction,
+    format_transformer_requirements,
+)
 
 # Enforce required dependencies
 try:
@@ -20,7 +25,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "transformers is required for RealismScorer. "
-        "Install with: pip install transformers==4.46.0\n"
+        f"{format_install_instruction('transformers', TRANSFORMERS_VERSION)}\n"
         "GPU Requirements: CUDA-capable GPU with 4GB+ VRAM recommended for full functionality. "
         "CPU-only mode available but slower."
     ) from e
@@ -70,13 +75,13 @@ class RealismScorer:
                         continue
                 else:
                     # All preferred models failed - raise error
+                    requirements = format_transformer_requirements(
+                        internet_note="- Internet connection to download models from HuggingFace Hub"
+                    )
                     raise RuntimeError(
                         f"Failed to load any preferred medical model. Last error: {last_error}\n"
                         f"Attempted models: {medical_models}\n"
-                        f"Requirements:\n"
-                        f"- transformers==4.46.0\n"
-                        f"- torch==2.5.1\n"
-                        f"- Internet connection to download models from HuggingFace Hub"
+                        f"{requirements}"
                     )
             else:
                 self.tokenizer = robust_model_download(
@@ -116,12 +121,12 @@ class RealismScorer:
                 self.perplexity_model = self.perplexity_model.to(self.device)
                 self.perplexity_model.eval()
             except (ModelDownloadError, Exception) as e:
+                requirements = format_transformer_requirements(
+                    internet_note="- Internet connection to download models from HuggingFace Hub"
+                )
                 raise RuntimeError(
                     f"Failed to initialize perplexity model (gpt2): {e}\n"
-                    f"Requirements:\n"
-                    f"- transformers==4.46.0\n"
-                    f"- torch==2.5.1\n"
-                    f"- Internet connection to download model from HuggingFace Hub"
+                    f"{requirements}"
                 ) from e
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- add `dependency_versions` utility with shared version constants and formatting helpers
- update generator, question generator, discriminator, and realism scorer to reuse shared dependency messaging
- align model loader import errors with centralized `pip install` guidance

## Testing
- python -m compileall phaita/utils/dependency_versions.py

------
https://chatgpt.com/codex/tasks/task_e_68e0b4518e148323a9e3ca41fb3875d9