### PR TITLE
Update COPD code references in challenge workflow

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -537,7 +537,7 @@ def challenge_command(args):
         # 1. Rare presentations
         print("\n📍 Category 1: Rare Presentations")
         for i in range(args.rare_cases):
-            condition_code = random.choice(["J45.9", "J44.1", "J18.9"])
+            condition_code = random.choice(["J45.9", "J44.9", "J18.9"])
             symptoms, metadata = network.sample_symptoms(
                 condition_code, 
                 include_rare=True,
@@ -557,7 +557,7 @@ def challenge_command(args):
         # Generate standard cases if no rare cases found
         if len(challenge_cases) == 0:
             for i in range(args.rare_cases):
-                condition_code = random.choice(["J45.9", "J44.1", "J18.9"])
+                condition_code = random.choice(["J45.9", "J44.9", "J18.9"])
                 symptoms, metadata = network.sample_symptoms(condition_code, severity="severe")
                 challenge_cases.append({
                     "type": "standard",
@@ -592,7 +592,7 @@ def challenge_command(args):
         print(f"\n📍 Category 3: Comorbidity-Influenced")
         comorbidity_cases = [
             ("J45.9", ["anxiety", "obesity"]),
-            ("J44.1", ["heart_failure"]),
+            ("J44.9", ["heart_failure"]),
             ("J18.9", ["immunocompromised"])
         ]
 

--- a/tests/test_cli_triage_workflow.py
+++ b/tests/test_cli_triage_workflow.py
@@ -127,7 +127,7 @@ def test_challenge_command_uses_information_loop(capsys):
                 "confidence_interval": (0.35, 0.78),
             },
             {
-                "condition_code": "J44.1",
+                "condition_code": "J44.9",
                 "condition_name": "COPD",
                 "probability": 0.16,
                 "confidence_interval": (0.04, 0.32),


### PR DESCRIPTION
## Summary
- replace the challenge-mode COPD ICD-10 code with the catalogued J44.9 value
- update the CLI triage workflow test fixture to expect the revised COPD code

## Testing
- PYTHONPATH=. pytest tests/test_cli_triage_workflow.py::test_challenge_command_uses_information_loop

------
https://chatgpt.com/codex/tasks/task_e_68e0d378dc9883238ece88daf91798db