### PR TITLE
Handle case-insensitive lay term augmentation

### DIFF
--- a/phaita/data/forum_scraper.py
+++ b/phaita/data/forum_scraper.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass, asdict
 from datetime import datetime
@@ -469,11 +470,10 @@ class ForumDataAugmentation:
             augmented_complaint = complaint
             for medical, lay_terms in self.mapper.reverse_mappings.items():
                 normalized_medical = medical.replace("_", " ")
-                if normalized_medical in augmented_complaint.lower():
+                pattern = re.compile(re.escape(normalized_medical), flags=re.IGNORECASE)
+                if pattern.search(augmented_complaint):
                     lay_term = lay_terms[0]
-                    augmented_complaint = augmented_complaint.replace(
-                        normalized_medical, lay_term
-                    )
+                    augmented_complaint = pattern.sub(lay_term, augmented_complaint)
             augmented.append(augmented_complaint)
         return augmented
 

--- a/tests/test_forum_scraping.py
+++ b/tests/test_forum_scraping.py
@@ -95,11 +95,18 @@ def test_data_augmentation():
         augmenter = create_data_augmentation()
         
         # Test complaint augmentation
-        complaints = ["Patient has dyspnea and chest pain", "Cough with fever present"]
+        complaints = [
+            "Patient has Dyspnea and Chest Pain",
+            "Cough with fever present",
+        ]
         condition_codes = ["J45.9", "J18.9"]
-        
+
         augmented = augmenter.augment_complaints_with_lay_terms(complaints, condition_codes)
         assert len(augmented) == len(complaints), "Should return same number of complaints"
+        assert "Dyspnea" not in augmented[0]
+        assert "Chest Pain" not in augmented[0]
+        assert "can't breathe" in augmented[0]
+        assert "chest hurts" in augmented[0]
         
         # Test forum complaints retrieval
         forum_complaints = augmenter.get_forum_complaints_for_pretraining(max_complaints=10)


### PR DESCRIPTION
## Summary
- update the complaint augmentation to replace medical terminology using case-insensitive regex matching while preserving surrounding casing
- extend the forum scraping augmentation test to cover capitalized medical terms and validate they are converted to lay language

## Testing
- pytest tests/test_forum_scraping.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d4b64a348323a7f26b7524584356